### PR TITLE
Removed mtools dependency, added tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,54 @@ docs/_build/
 
 # PyBuilder
 target/
+
+### OSX ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+.history
+
+### VirtualEnv ###
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+.Python
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Mm]an
+[Ss]cripts
+[Tt]cl
+pyvenv.cfg
+.venv
+pip-selfcheck.json

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ python fruitsalad.py <logfile>
 
 to output the scrambled version to _stdout_, or redirect the output to a file by adding `> redacted.log` to the end of the command.
 
+### Tests
+
+`fruitsalad` uses [nose](https://github.com/nose-devs/nose) for testing. Please follow the instructions in the [nose documentation page](https://nose.readthedocs.io/en/latest/) for the recommended method to install nose. After nose is installed, testing could be done by running:
+
+```
+nosetests -v
+```
+
+in `fruitsalad`'s root directory. The `-v` is optional, and is only used to display a more verbose testing messages.
 
 ### DISCLAMER
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This is a very early beta version.
 
 ### Usage
 
-You need to have [mtools](https://github.com/rueckstiess/mtools) installed and linked in your `PYTHONPATH` in order for fruitsalad to work. Then run:
-
 ```
 python fruitsalad.py <logfile>
 ```

--- a/fruitsalad.py
+++ b/fruitsalad.py
@@ -12,7 +12,7 @@ fruits = ['apple', 'apricot', 'avocado', 'banana', 'breadfruit', 'bilberry', 'bl
 class FruitSaladTool():
     """ replace IP addresses, hostnames, namespaces, strings with random values. """
 
-    def __init__(self, arg_seed=None, arg_logfile=None):
+    def __init__(self, arg_logfile, arg_seed=None):
         self.seed = arg_seed
         self.logfile = arg_logfile
         self.replacements = {}

--- a/fruitsalad.py
+++ b/fruitsalad.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 
-from mtools.util.logfile import LogFile
-from mtools.util.logevent import LogEvent
-from mtools.util.cmdlinetool import LogFileTool
 from random import seed, randrange, choice
-
-import pprint
+import argparse
 import re
 import hashlib
 
@@ -13,16 +9,12 @@ adjectives = ["acerbic", "acidic", "acrid", "aged", "ambrosial", "ample", "appea
 colors = ['aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige', 'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown', 'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral', 'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue', 'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgreen', 'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange', 'darkorchid', 'darkred', 'darksalmon', 'darkseagreen', 'darkslateblue', 'darkslategray', 'darkturquoise', 'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia', 'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred', 'indigo', 'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen', 'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan', 'lightgoldenrodyellow', 'lightgray', 'lightgreen', 'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue', 'lightslategray', 'lightsteelblue', 'lightyellow', 'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine', 'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen', 'mediumslateblue', 'mediumspringgreen', 'mediumturquoise', 'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose', 'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab', 'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen', 'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru', 'pink', 'plum', 'powderblue', 'purple', 'red', 'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown', 'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue', 'slategray', 'snow', 'springgreen', 'steelblue', 'tan', 'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white', 'whitesmoke', 'yellow', 'yellowgreen']
 fruits = ['apple', 'apricot', 'avocado', 'banana', 'breadfruit', 'bilberry', 'blackberry', 'blackcurrant', 'blueberry', 'boysenberry', 'cantaloupe', 'currant', 'cherry', 'cherimoya', 'cloudberry', 'coconut', 'cranberry', 'cucumber', 'damson', 'date', 'dragonfruit', 'durian', 'eggplant', 'elderberry', 'feijoa', 'fig', 'goji.berry', 'gooseberry', 'grape', 'raisin', 'grapefruit', 'guava', 'huckleberry', 'honeydew', 'jackfruit', 'jambul', 'jujube', 'kiwi.fruit', 'kumquat', 'lemon', 'lime', 'loquat', 'lychee', 'mango', 'marion.berry', 'melon', 'cantaloupe', 'honeydew', 'watermelon', 'rock.melon', 'miracle.fruit', 'mulberry', 'nectarine', 'nut', 'olive', 'orange', 'clementine', 'mandarine', 'blood.orange', 'tangerine', 'papaya', 'passionfruit', 'peach', 'pepper', 'chili.pepper', 'bell.pepper', 'pear', 'williams.pear.or.bartlett.pear', 'persimmon', 'physalis', 'pineapple', 'pomegranate', 'pomelo', 'mangosteen', 'quince', 'raspberry', 'western.raspberry', 'rambutan', 'redcurrant', 'salal.berry', 'salmon.berry', 'satsuma', 'star.fruit', 'strawberry', 'tamarillo', 'tomato', 'ugli.fruit', 'watermelon']
 
-class FruitSaladTool(LogFileTool):
+class FruitSaladTool():
     """ replace IP addresses, hostnames, namespaces, strings with random values. """
 
-    def __init__(self):
-        """ Constructor: add description to argparser. """
-        LogFileTool.__init__(self, multiple_logfiles=False, stdin_allowed=True)
-
-        self.argparser.description = 'Anonymizes log files by replacing IP addresses, namespaces, strings.'
-        self.argparser.add_argument('--seed', '-s', action='store', metavar='S', default=None, help='seed the random number generator with S (any string)')
-
+    def __init__(self, arg_seed=None, arg_logfile=None):
+        self.seed = arg_seed
+        self.logfile = arg_logfile
         self.replacements = {}
 
 
@@ -64,15 +56,14 @@ class FruitSaladTool(LogFileTool):
         return '"' + hashlib.md5(match.group(0)).hexdigest() + '"'
 
 
-    def run(self, arguments=None):
+    def run(self):
         """ Print out useful information about the log file. """
-        LogFileTool.run(self, arguments)
 
-        if self.args['seed'] != None:
-            seed(self.args['seed'])
+        if self.seed != None:
+            seed(self.seed)
 
-        for logevent in self.args['logfile']:
-            line = logevent.line_str
+        for logevent in open(self.logfile, 'r'):
+            line = logevent
 
             # replace IP addresses
             line = re.sub(r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', self._replace_ip, line)
@@ -83,10 +74,15 @@ class FruitSaladTool(LogFileTool):
             # replace hostnames and namespaces
             line = re.sub(r'[a-zA-Z$][^ \t\n\r\f\v:]+(\.[a-zA-Z$][^ \t\n\r\f\v:]+)+', self._replace_dottedname, line)
 
-            print line
+            print line.strip()
 
 
 if __name__ == '__main__':
-    tool = FruitSaladTool()
-    tool.run()
+    argparser = argparse.ArgumentParser()
+    argparser.description = 'Anonymizes log files by replacing IP addresses, namespaces, strings.'
+    argparser.add_argument('--seed', '-s', action='store', metavar='S', default=None, help='seed the random number generator with S (any string)')
+    argparser.add_argument('logfile', type=str)
+    args = argparser.parse_args()
 
+    tool = FruitSaladTool(arg_seed=args.seed, arg_logfile=args.logfile)
+    tool.run()

--- a/fruitsalad_test.py
+++ b/fruitsalad_test.py
@@ -15,8 +15,8 @@ class TestFruitSalad(unittest.TestCase):
         sys.stdout = self.saved_stdout
 
     def test_milliseconds(self):
-        ''' Timestamps should be printed correctly '''
-        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        ''' Timestamps should be printed unmodified '''
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         self.assertEqual(output[0], '2017-08-25T22:23:49.097+0000 I COMMAND [conn0]')
@@ -24,22 +24,22 @@ class TestFruitSalad(unittest.TestCase):
 
     def test_namespace(self):
         ''' Namespaces should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
-        self.assertEqual(output[2], '2017-09-04T12:07:36.596+1000 D COMMAND  [conn6] run command darkgray.$cmd { find: "303b5c8988601647873b4ffd247d83cb", filter: { key: 1.0 } }')
+        self.assertEqual(output[2], '2017-09-04T12:07:36.596+1000 D COMMAND  [conn6] run command sandybrown.$cmd { find: "303b5c8988601647873b4ffd247d83cb", filter: { key: 1.0 } }')
 
     def test_ip_1(self):
         ''' IP addresses not 127.0.0.1 should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
-        self.assertEqual(output[7], '2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 192.168.49.147:57139 #6 (1 connection now open)')
-        self.assertEqual(output[8], '2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 192.168.49.147:57139 (2 connections now open)')
+        self.assertEqual(output[7], '2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 192.168.148.231:57139 #6 (1 connection now open)')
+        self.assertEqual(output[8], '2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 192.168.148.231:57139 (2 connections now open)')
 
     def test_ip_2(self):
         ''' IP addresses 127.0.0.1 should not be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         self.assertEqual(output[9], '2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 127.0.0.1:57139 #6 (1 connection now open)')
@@ -47,7 +47,7 @@ class TestFruitSalad(unittest.TestCase):
 
     def test_2_4(self):
         ''' MongoDB 2.4 log file should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.2.4.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.2.4.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         for sample in zip([line.strip() for line in open('test/sample_redacted.2.4.log', 'r')], output):
@@ -55,7 +55,7 @@ class TestFruitSalad(unittest.TestCase):
 
     def test_2_6(self):
         ''' MongoDB 2.6 log file should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.2.6.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.2.6.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         for sample in zip([line.strip() for line in open('test/sample_redacted.2.6.log', 'r')], output):
@@ -63,7 +63,7 @@ class TestFruitSalad(unittest.TestCase):
 
     def test_3_0(self):
         ''' MongoDB 3.0 log file should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.3.0.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.3.0.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         for sample in zip([line.strip() for line in open('test/sample_redacted.3.0.log', 'r')], output):
@@ -71,7 +71,7 @@ class TestFruitSalad(unittest.TestCase):
 
     def test_3_2(self):
         ''' MongoDB 3.2 log file should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.3.2.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.3.2.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         for sample in zip([line.strip() for line in open('test/sample_redacted.3.2.log', 'r')], output):
@@ -79,7 +79,7 @@ class TestFruitSalad(unittest.TestCase):
 
     def test_3_4(self):
         ''' MongoDB 3.4 log file should be redacted '''
-        tool = FruitSaladTool(arg_logfile='test/sample.3.4.log', arg_seed='test')
+        tool = FruitSaladTool(arg_logfile='test/sample.3.4.log', arg_seed=0)
         tool.run()
         output = self.stdout.getvalue().split('\n')
         for sample in zip([line.strip() for line in open('test/sample_redacted.3.4.log', 'r')], output):

--- a/fruitsalad_test.py
+++ b/fruitsalad_test.py
@@ -1,0 +1,86 @@
+import unittest
+import io
+import sys
+from fruitsalad import FruitSaladTool
+
+class TestFruitSalad(unittest.TestCase):
+    ''' Basic tests of fruit salad MongoDB log redacter '''
+
+    def setUp(self):
+        self.saved_stdout = sys.stdout
+        self.stdout = io.BytesIO()
+        sys.stdout = self.stdout
+
+    def tearDown(self):
+        sys.stdout = self.saved_stdout
+
+    def test_milliseconds(self):
+        ''' Timestamps should be printed correctly '''
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        self.assertEqual(output[0], '2017-08-25T22:23:49.097+0000 I COMMAND [conn0]')
+        self.assertEqual(output[1], '2017-08-25T22:23:49.007+1000 I COMMAND [conn0]')
+
+    def test_namespace(self):
+        ''' Namespaces should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        self.assertEqual(output[2], '2017-09-04T12:07:36.596+1000 D COMMAND  [conn6] run command darkgray.$cmd { find: "303b5c8988601647873b4ffd247d83cb", filter: { key: 1.0 } }')
+
+    def test_ip_1(self):
+        ''' IP addresses not 127.0.0.1 should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        self.assertEqual(output[7], '2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 192.168.49.147:57139 #6 (1 connection now open)')
+        self.assertEqual(output[8], '2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 192.168.49.147:57139 (2 connections now open)')
+
+    def test_ip_2(self):
+        ''' IP addresses 127.0.0.1 should not be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.ts.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        self.assertEqual(output[9], '2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 127.0.0.1:57139 #6 (1 connection now open)')
+        self.assertEqual(output[10], '2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 127.0.0.1:57139 (2 connections now open)')
+
+    def test_2_4(self):
+        ''' MongoDB 2.4 log file should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.2.4.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        for sample in zip([line.strip() for line in open('test/sample_redacted.2.4.log', 'r')], output):
+            self.assertEqual(sample[0], sample[1])
+
+    def test_2_6(self):
+        ''' MongoDB 2.6 log file should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.2.6.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        for sample in zip([line.strip() for line in open('test/sample_redacted.2.6.log', 'r')], output):
+            self.assertEqual(sample[0], sample[1])
+
+    def test_3_0(self):
+        ''' MongoDB 3.0 log file should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.3.0.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        for sample in zip([line.strip() for line in open('test/sample_redacted.3.0.log', 'r')], output):
+            self.assertEqual(sample[0], sample[1])
+
+    def test_3_2(self):
+        ''' MongoDB 3.2 log file should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.3.2.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        for sample in zip([line.strip() for line in open('test/sample_redacted.3.2.log', 'r')], output):
+            self.assertEqual(sample[0], sample[1])
+
+    def test_3_4(self):
+        ''' MongoDB 3.4 log file should be redacted '''
+        tool = FruitSaladTool(arg_logfile='test/sample.3.4.log', arg_seed='test')
+        tool.run()
+        output = self.stdout.getvalue().split('\n')
+        for sample in zip([line.strip() for line in open('test/sample_redacted.3.4.log', 'r')], output):
+            self.assertEqual(sample[0], sample[1])

--- a/test/sample.2.4.log
+++ b/test/sample.2.4.log
@@ -1,0 +1,47 @@
+Mon Sep  4 15:25:31.160 [initandlisten] MongoDB starting : pid=96748 port=27017 dbpath=/data/db 64-bit host=mongodb.local
+Mon Sep  4 15:25:31.160 [initandlisten] db version v2.4.14
+Mon Sep  4 15:25:31.160 [initandlisten] git version: 05bebf9ab15511a71bfbded684bb226014c0a553
+Mon Sep  4 15:25:31.160 [initandlisten] build info: Darwin bs-osx-106-x86-64-2.10gen.cc 10.8.0 Darwin Kernel Version 10.8.0: Tue Jun  7 16:32:41 PDT 2011; root:xnu-1504.15.3~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+Mon Sep  4 15:25:31.160 [initandlisten] allocator: system
+Mon Sep  4 15:25:31.160 [initandlisten] options: { dbpath: "/data/db", fork: true, logappend: true, logpath: "/data/mongod.log", port: 27017 }
+Mon Sep  4 15:25:31.161 [initandlisten] journal dir=/data/db/journal
+Mon Sep  4 15:25:31.161 [initandlisten] recover : no journal files present, no recovery needed
+Mon Sep  4 15:25:31.170 [initandlisten] allocating new ns file /data/db/local.ns, filling with zeroes...
+Mon Sep  4 15:25:31.214 [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
+Mon Sep  4 15:25:31.214 [FileAllocator] creating directory /data/db/_tmp
+Mon Sep  4 15:25:31.311 [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.096 secs
+Mon Sep  4 15:25:31.328 [initandlisten] command local.$cmd command: { create: "startup_log", size: 10485760, capped: true } ntoreturn:1 keyUpdates:0  reslen:37 157ms
+Mon Sep  4 15:25:31.330 [websvr] admin web console waiting for connections on port 28017
+Mon Sep  4 15:25:31.330 [initandlisten] waiting for connections on port 27017
+Mon Sep  4 15:25:31.680 [initandlisten] connection accepted from 127.0.0.1:56846 #1 (1 connection now open)
+Mon Sep  4 15:25:32.185 [conn1] end connection 127.0.0.1:56846 (3 connections now open)
+Mon Sep  4 15:26:00.562 [conn6] allocating new ns file /data/db/test.ns, filling with zeroes...
+Mon Sep  4 15:26:00.593 [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
+Mon Sep  4 15:26:00.695 [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.101 secs
+Mon Sep  4 15:26:00.713 [FileAllocator] allocating new datafile /data/db/test.1, filling with zeroes...
+Mon Sep  4 15:26:00.714 [conn6] build index test.test { _id: 1 }
+Mon Sep  4 15:26:00.755 [conn6] build index done.  scanned 0 total records. 0.04 secs
+Mon Sep  4 15:26:00.755 [conn6] insert test.test ninserted:1 keyUpdates:0 locks(micros) w:192860 192ms
+Mon Sep  4 15:26:00.926 [FileAllocator] done allocating datafile /data/db/test.1, size: 128MB,  took 0.212 secs
+Mon Sep  4 15:26:38.142 [conn6] creating profile collection: test.system.profile
+Mon Sep  4 15:26:48.923 [conn6] query test.test query: { key: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:215 nreturned:0 reslen:20 0ms
+Mon Sep  4 15:27:18.286 [conn6] query test.test query: { key.array: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:138 nreturned:0 reslen:20 0ms
+Mon Sep  4 15:27:22.462 [conn6] end connection 127.0.0.1:56852 (0 connections now open)
+Mon Sep  4 15:27:27.149 [conn8] command admin.$cmd command: { ping: 1 } ntoreturn:1 keyUpdates:0  reslen:37 0ms
+Mon Sep  4 15:27:27.170 [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+Mon Sep  4 15:27:27.171 [signalProcessingThread] now exiting
+Mon Sep  4 15:27:27.171 dbexit: 
+Mon Sep  4 15:27:27.171 [signalProcessingThread] shutdown: going to close listening sockets...
+Mon Sep  4 15:27:27.171 [signalProcessingThread] closing listening socket: 10
+Mon Sep  4 15:27:27.172 [signalProcessingThread] removing socket file: /tmp/mongodb-27017.sock
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: going to flush diaglog...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: going to close sockets...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: waiting for fs preallocator...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: lock for final commit...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: final commit...
+Mon Sep  4 15:27:27.180 [signalProcessingThread] shutdown: closing all files...
+Mon Sep  4 15:27:27.180 [signalProcessingThread] closeAllFiles() finished
+Mon Sep  4 15:27:27.180 [signalProcessingThread] journalCleanup...
+Mon Sep  4 15:27:27.180 [signalProcessingThread] removeJournalFiles
+Mon Sep  4 15:27:27.181 [signalProcessingThread] shutdown: removing fs lock...
+Mon Sep  4 15:27:27.181 dbexit: really exiting now

--- a/test/sample.2.6.log
+++ b/test/sample.2.6.log
@@ -1,0 +1,73 @@
+2017-09-04T15:53:44.521+1000 [initandlisten] MongoDB starting : pid=98141 port=27017 dbpath=/data/db 64-bit host=mongodb.local
+2017-09-04T15:53:44.521+1000 [initandlisten] db version v2.6.12
+2017-09-04T15:53:44.521+1000 [initandlisten] git version: d73c92b1c85703828b55c2916a5dd4ad46535f6a
+2017-09-04T15:53:44.521+1000 [initandlisten] build info: Darwin mci-osx108-11.build.10gen.cc 12.5.0 Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47 PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+2017-09-04T15:53:44.521+1000 [initandlisten] allocator: system
+2017-09-04T15:53:44.521+1000 [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "/data/db" }, systemLog: { destination: "file", logAppend: true, path: "/data/mongod.log" } }
+2017-09-04T15:53:44.522+1000 [initandlisten] journal dir=/data/db/journal
+2017-09-04T15:53:44.523+1000 [initandlisten] recover : no journal files present, no recovery needed
+2017-09-04T15:53:44.535+1000 [initandlisten] allocating new ns file /data/db/local.ns, filling with zeroes...
+2017-09-04T15:53:44.565+1000 [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
+2017-09-04T15:53:44.565+1000 [FileAllocator] creating directory /data/db/_tmp
+2017-09-04T15:53:44.679+1000 [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.112 secs
+2017-09-04T15:53:44.700+1000 [initandlisten] build index on: local.startup_log properties: { v: 1, key: { _id: 1 }, name: "_id_", ns: "local.startup_log" }
+2017-09-04T15:53:44.701+1000 [initandlisten] 	 added index to empty collection
+2017-09-04T15:53:44.701+1000 [initandlisten] command local.$cmd command: create { create: "startup_log", size: 10485760, capped: true } ntoreturn:1 keyUpdates:0 numYields:0  reslen:37 166ms
+2017-09-04T15:53:44.702+1000 [initandlisten] waiting for connections on port 27017
+2017-09-04T15:53:44.702+1000 [initandlisten] connection accepted from 127.0.0.1:57011 #1 (1 connection now open)
+2017-09-04T15:53:44.705+1000 [initandlisten] connection accepted from 127.0.0.1:57013 #2 (2 connections now open)
+2017-09-04T15:53:44.707+1000 [conn1] end connection 127.0.0.1:57011 (1 connection now open)
+2017-09-04T15:53:44.707+1000 [conn2] end connection 127.0.0.1:57013 (1 connection now open)
+2017-09-04T15:53:44.708+1000 [initandlisten] connection accepted from 127.0.0.1:57014 #3 (1 connection now open)
+2017-09-04T15:53:44.710+1000 [initandlisten] connection accepted from 127.0.0.1:57015 #4 (2 connections now open)
+2017-09-04T15:53:44.711+1000 [conn4] end connection 127.0.0.1:57015 (1 connection now open)
+2017-09-04T15:53:44.711+1000 [conn3] end connection 127.0.0.1:57014 (1 connection now open)
+2017-09-04T15:53:49.531+1000 [initandlisten] connection accepted from 127.0.0.1:57017 #5 (1 connection now open)
+2017-09-04T15:54:06.065+1000 [conn5] end connection 127.0.0.1:57017 (0 connections now open)
+2017-09-04T15:54:08.781+1000 [initandlisten] connection accepted from 127.0.0.1:57019 #6 (1 connection now open)
+2017-09-04T15:54:13.452+1000 [conn6] creating profile collection: test.system.profile
+2017-09-04T15:54:13.453+1000 [conn6] allocating new ns file /data/db/test.ns, filling with zeroes...
+2017-09-04T15:54:13.499+1000 [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
+2017-09-04T15:54:13.596+1000 [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.097 secs
+2017-09-04T15:54:13.602+1000 [conn6] command test.$cmd command: profile { profile: 2.0, slowms: -1.0 } keyUpdates:0 numYields:0 locks(micros) w:149813 reslen:58 149ms
+2017-09-04T15:54:13.605+1000 [conn6] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:20.630+1000 [conn6] command admin.$cmd command: isMaster { isMaster: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:20.635+1000 [conn6] build index on: test.test properties: { v: 1, key: { _id: 1 }, name: "_id_", ns: "test.test" }
+2017-09-04T15:54:20.635+1000 [conn6] 	 added index to empty collection
+2017-09-04T15:54:20.635+1000 [conn6] insert test.test query: { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:2561 2ms
+2017-09-04T15:54:20.636+1000 [conn6] command test.$cmd command: insert { insert: "test", documents: [ { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:228 reslen:40 3ms
+2017-09-04T15:54:20.637+1000 [conn6] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:21.929+1000 [conn6] insert test.test query: { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:119 0ms
+2017-09-04T15:54:21.930+1000 [conn6] command test.$cmd command: insert { insert: "test", documents: [ { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:423 reslen:40 0ms
+2017-09-04T15:54:21.931+1000 [conn6] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:23.163+1000 [conn6] insert test.test query: { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:35 0ms
+2017-09-04T15:54:23.163+1000 [conn6] command test.$cmd command: insert { insert: "test", documents: [ { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:402 reslen:40 0ms
+2017-09-04T15:54:23.164+1000 [conn6] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:29.589+1000 [conn6] query test.test query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:1046 nreturned:1 reslen:55 1ms
+2017-09-04T15:54:29.590+1000 [conn6] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:34.580+1000 [conn6] query test.test query: { key.array: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:112 nreturned:0 reslen:20 0ms
+2017-09-04T15:54:34.581+1000 [conn6] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:35.837+1000 [conn6] end connection 127.0.0.1:57019 (0 connections now open)
+2017-09-04T15:54:39.491+1000 [initandlisten] connection accepted from 127.0.0.1:57020 #7 (1 connection now open)
+2017-09-04T15:54:39.495+1000 [initandlisten] connection accepted from 127.0.0.1:57021 #8 (2 connections now open)
+2017-09-04T15:54:39.496+1000 [conn8] command admin.$cmd command: ping { ping: 1 } keyUpdates:0 numYields:0  reslen:37 0ms
+2017-09-04T15:54:39.496+1000 [conn7] end connection 127.0.0.1:57020 (1 connection now open)
+2017-09-04T15:54:39.496+1000 [conn8] end connection 127.0.0.1:57021 (1 connection now open)
+2017-09-04T15:54:39.515+1000 [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] now exiting
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] dbexit: 
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] closing listening socket: 9
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] closing listening socket: 10
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] removing socket file: /tmp/mongodb-27017.sock
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: going to close sockets...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: waiting for fs preallocator...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: lock for final commit...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: final commit...
+2017-09-04T15:54:39.526+1000 [signalProcessingThread] shutdown: closing all files...
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] closeAllFiles() finished
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] journalCleanup...
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] removeJournalFiles
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] dbexit: really exiting now

--- a/test/sample.3.0.log
+++ b/test/sample.3.0.log
@@ -1,0 +1,104 @@
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] MongoDB starting : pid=98413 port=27017 dbpath=/data/db 64-bit host=mongodb.local
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] db version v3.0.15
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] git version: b8ff507269c382bc100fc52f75f48d54cd42ec3b
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] build info: Darwin mci-osx1010-9.build.10gen.cc 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] allocator: system
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "/data/db" }, systemLog: { destination: "file", logAppend: true, path: "/data/mongod.log" } }
+2017-09-04T15:59:46.850+1000 I JOURNAL  [initandlisten] journal dir=/data/db/journal
+2017-09-04T15:59:46.851+1000 I JOURNAL  [initandlisten] recover : no journal files present, no recovery needed
+2017-09-04T15:59:46.863+1000 I JOURNAL  [durability] Durability thread started
+2017-09-04T15:59:46.863+1000 I JOURNAL  [journal writer] Journal writer thread started
+2017-09-04T15:59:46.867+1000 I INDEX    [initandlisten] allocating new ns file /data/db/local.ns, filling with zeroes...
+2017-09-04T15:59:46.911+1000 I STORAGE  [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
+2017-09-04T15:59:46.912+1000 I STORAGE  [FileAllocator] creating directory /data/db/_tmp
+2017-09-04T15:59:47.038+1000 I STORAGE  [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.125 secs
+2017-09-04T15:59:47.074+1000 I NETWORK  [initandlisten] waiting for connections on port 27017
+2017-09-04T15:59:47.174+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57049 #1 (1 connection now open)
+2017-09-04T15:59:47.200+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57050 #2 (2 connections now open)
+2017-09-04T15:59:47.203+1000 I NETWORK  [conn2] end connection 127.0.0.1:57050 (1 connection now open)
+2017-09-04T15:59:47.203+1000 I NETWORK  [conn1] end connection 127.0.0.1:57049 (1 connection now open)
+2017-09-04T15:59:47.204+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57051 #3 (1 connection now open)
+2017-09-04T15:59:47.206+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57052 #4 (2 connections now open)
+2017-09-04T15:59:47.207+1000 I NETWORK  [conn3] end connection 127.0.0.1:57051 (1 connection now open)
+2017-09-04T15:59:47.207+1000 I NETWORK  [conn4] end connection 127.0.0.1:57052 (1 connection now open)
+2017-09-04T15:59:53.146+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57055 #5 (1 connection now open)
+2017-09-04T16:00:01.638+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:01.638+1000 I COMMAND  [conn5] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:08.664+1000 D COMMAND  [conn5] run command admin.$cmd { isMaster: 1.0 }
+2017-09-04T16:00:08.664+1000 I COMMAND  [conn5] command admin.$cmd command: isMaster { isMaster: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:08.667+1000 D COMMAND  [conn5] run command test.$cmd { insert: "test", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true }
+2017-09-04T16:00:08.668+1000 I INDEX    [conn5] allocating new ns file /data/db/test.ns, filling with zeroes...
+2017-09-04T16:00:08.726+1000 I STORAGE  [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
+2017-09-04T16:00:08.904+1000 I STORAGE  [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.177 secs
+2017-09-04T16:00:08.924+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.924+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.926+1000 D STORAGE  [conn5] allocating new extent
+2017-09-04T16:00:08.927+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:4096 fromFreeList: 0 eloc: 0:4000
+2017-09-04T16:00:08.927+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.927+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] test.system.indexes: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] test.system.namespaces: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:8192 fromFreeList: 0 eloc: 0:5000
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] test.test: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] allocating new extent
+2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:8192 fromFreeList: 0 eloc: 0:7000
+2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] allocating new extent
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:131072 fromFreeList: 0 eloc: 0:9000
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] test.test: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.937+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.937+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.937+1000 I WRITE    [conn5] insert test.test query: { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
+2017-09-04T16:00:08.937+1000 I COMMAND  [conn5] command test.$cmd command: insert { insert: "test", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
+2017-09-04T16:00:08.939+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:08.939+1000 I COMMAND  [conn5] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:10.205+1000 D COMMAND  [conn5] run command test.$cmd { insert: "test", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true }
+2017-09-04T16:00:10.205+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:10.206+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:10.206+1000 I WRITE    [conn5] insert test.test query: { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:10.206+1000 I COMMAND  [conn5] command test.$cmd command: insert { insert: "test", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:10.207+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:10.207+1000 I COMMAND  [conn5] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:11.569+1000 D COMMAND  [conn5] run command test.$cmd { insert: "test", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true }
+2017-09-04T16:00:11.570+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:11.570+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:11.570+1000 I WRITE    [conn5] insert test.test query: { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:11.570+1000 I COMMAND  [conn5] command test.$cmd command: insert { insert: "test", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:11.571+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:11.571+1000 I COMMAND  [conn5] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:17.402+1000 D QUERY    [conn5] Running query: query: { key: 1.0 } sort: {} projection: {} skip: 0 limit: 0
+2017-09-04T16:00:17.404+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { key: 1.0 } sort: {} projection: {} skip: 0 limit: 0, planSummary: COLLSCAN
+2017-09-04T16:00:17.405+1000 I COMMAND  [conn5] query test.test query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:3 keyUpdates:0 writeConflicts:0 numYields:0 nreturned:1 reslen:55 locks:{ Global: { acquireCount: { r: 2 } }, MMAPV1Journal: { acquireCount: { r: 1 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { R: 1 } } } 3ms
+2017-09-04T16:00:17.406+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:17.406+1000 I COMMAND  [conn5] command test.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:23.932+1000 D NETWORK  [conn5] SocketException: remote: 127.0.0.1:57055 error: 9001 socket exception [CLOSED] server [127.0.0.1:57055] 
+2017-09-04T16:00:23.932+1000 I NETWORK  [conn5] end connection 127.0.0.1:57055 (0 connections now open)
+2017-09-04T16:00:26.731+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57058 #6 (1 connection now open)
+2017-09-04T16:00:26.734+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57059 #7 (2 connections now open)
+2017-09-04T16:00:26.735+1000 D COMMAND  [conn7] run command admin.$cmd { ping: 1 }
+2017-09-04T16:00:26.736+1000 I COMMAND  [conn7] command admin.$cmd command: ping { ping: 1 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:37 locks:{} 0ms
+2017-09-04T16:00:26.736+1000 D NETWORK  [conn7] SocketException: remote: 127.0.0.1:57059 error: 9001 socket exception [CLOSED] server [127.0.0.1:57059] 
+2017-09-04T16:00:26.736+1000 D NETWORK  [conn6] SocketException: remote: 127.0.0.1:57058 error: 9001 socket exception [CLOSED] server [127.0.0.1:57058] 
+2017-09-04T16:00:26.736+1000 I NETWORK  [conn7] end connection 127.0.0.1:57059 (1 connection now open)
+2017-09-04T16:00:26.737+1000 I NETWORK  [conn6] end connection 127.0.0.1:57058 (1 connection now open)
+2017-09-04T16:00:26.755+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T16:00:26.755+1000 I CONTROL  [signalProcessingThread] now exiting
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] closing listening socket: 7
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] removing socket file: /tmp/mongodb-27017.sock
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T16:00:26.757+1000 I NETWORK  [signalProcessingThread] shutdown: going to close sockets...
+2017-09-04T16:00:26.757+1000 I STORAGE  [signalProcessingThread] shutdown: waiting for fs preallocator...
+2017-09-04T16:00:26.757+1000 I STORAGE  [signalProcessingThread] shutdown: final commit...
+2017-09-04T16:00:26.767+1000 I JOURNAL  [signalProcessingThread] journalCleanup...
+2017-09-04T16:00:26.767+1000 I JOURNAL  [signalProcessingThread] removeJournalFiles
+2017-09-04T16:00:26.768+1000 D JOURNAL  [signalProcessingThread] removeJournalFiles end
+2017-09-04T16:00:26.768+1000 I JOURNAL  [signalProcessingThread] Terminating durability thread ...
+2017-09-04T16:00:26.867+1000 I JOURNAL  [journal writer] Journal writer thread stopped
+2017-09-04T16:00:26.867+1000 I JOURNAL  [durability] Durability thread stopped
+2017-09-04T16:00:26.868+1000 I STORAGE  [signalProcessingThread] shutdown: closing all files...
+2017-09-04T16:00:26.869+1000 I STORAGE  [signalProcessingThread] closeAllFiles() finished
+2017-09-04T16:00:26.870+1000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T16:00:26.870+1000 I CONTROL  [signalProcessingThread] dbexit:  rc: 0

--- a/test/sample.3.2.log
+++ b/test/sample.3.2.log
@@ -1,0 +1,40 @@
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] MongoDB starting : pid=99243 port=27017 dbpath=/data/db 64-bit host=mongodb.local
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] db version v3.2.14
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] git version: 92f6668a768ebf294bd4f494c50f48459198e6a3
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 0.9.8zh 14 Jan 2016
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] allocator: system
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] modules: none
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] build environment:
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten]     distarch: x86_64
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten]     target_arch: x86_64
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "/Users/kevinadi/Development/mlaunch-data/transient/data/db", wiredTiger: { engineConfig: { cacheSizeGB: 1 } } }, systemLog: { destination: "file", logAppend: true, path: "/data/mongod.log" } }
+2017-09-04T16:07:03.263+1000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=1G,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
+2017-09-04T16:07:04.119+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/data/db/diagnostic.data'
+2017-09-04T16:07:04.119+1000 I NETWORK  [HostnameCanonicalizationWorker] Starting hostname canonicalization worker
+2017-09-04T16:07:04.119+1000 I NETWORK  [initandlisten] waiting for connections on port 27017
+2017-09-04T16:07:04.136+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57104 #1 (1 connection now open)
+2017-09-04T16:07:04.170+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57105 #2 (2 connections now open)
+2017-09-04T16:07:04.171+1000 I NETWORK  [conn1] end connection 10.0.0.1:57104 (1 connection now open)
+2017-09-04T16:07:04.171+1000 I NETWORK  [conn2] end connection 10.0.0.1:57105 (1 connection now open)
+2017-09-04T16:07:04.178+1000 I NETWORK  [initandlisten] connection accepted from 10.0.0.1:57106 #3 (1 connection now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [initandlisten] connection accepted from 10.0.0.1:57107 #4 (2 connections now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [conn3] end connection 10.0.0.1:57106 (1 connection now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [conn4] end connection 10.0.0.1:57107 (1 connection now open)
+2017-09-04T16:07:07.217+1000 I NETWORK  [initandlisten] connection accepted from 10.0.0.1:57110 #5 (1 connection now open)
+2017-09-04T16:08:08.159+1000 I NETWORK  [conn5] end connection 10.0.0.1:57110 (0 connections now open)
+2017-09-04T16:08:10.922+1000 I NETWORK  [initandlisten] connection accepted from 10.0.0.1:57114 #6 (1 connection now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [initandlisten] connection accepted from 10.0.0.1:57115 #7 (2 connections now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [conn6] end connection 10.0.0.1:57114 (1 connection now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [conn7] end connection 10.0.0.1:57115 (1 connection now open)
+2017-09-04T16:08:10.945+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T16:08:10.946+1000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
+2017-09-04T16:08:10.947+1000 I CONTROL  [signalProcessingThread] now exiting
+2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] closing listening socket: 7
+2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] removing socket file: /tmp/mongodb-27017.sock
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] shutdown: going to close sockets...
+2017-09-04T16:08:10.948+1000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
+2017-09-04T16:08:11.128+1000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T16:08:11.130+1000 I CONTROL  [signalProcessingThread] dbexit:  rc: 0

--- a/test/sample.3.4.log
+++ b/test/sample.3.4.log
@@ -1,0 +1,90 @@
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] MongoDB starting : pid=99463 port=27017 dbpath=/data/db 64-bit host=local
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] db version v3.4.7
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] git version: cf38c1b8a0a8dca4a11737581beafef4fe120bcd
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 0.9.8zh 14 Jan 2016
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] allocator: system
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] modules: none
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] build environment:
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten]     distarch: x86_64
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten]     target_arch: x86_64
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "/data/db", wiredTiger: { engineConfig: { cacheSizeGB: 1.0 } } }, systemLog: { destination: "file", logAppend: true, path: "/data/mongod.log" } }
+2017-09-04T16:12:03.204+1000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=1024M,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] 
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] 
+2017-09-04T16:12:03.939+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/data/db/diagnostic.data'
+2017-09-04T16:12:04.222+1000 I INDEX    [initandlisten] build index on: admin.system.version properties: { v: 2, key: { version: 1 }, name: "incompatible_with_version_32", ns: "admin.system.version" }
+2017-09-04T16:12:04.222+1000 I INDEX    [initandlisten] 	 building index using bulk method; build may temporarily use up to 500 megabytes of RAM
+2017-09-04T16:12:04.236+1000 I INDEX    [initandlisten] build index done.  scanned 0 total records. 0 secs
+2017-09-04T16:12:04.236+1000 I COMMAND  [initandlisten] setting featureCompatibilityVersion to 3.4
+2017-09-04T16:12:04.236+1000 I NETWORK  [thread1] waiting for connections on port 27017
+2017-09-04T16:12:04.240+1000 I NETWORK  [thread1] connection accepted from 127.0.0.1:57134 #1 (1 connection now open)
+2017-09-04T16:12:04.248+1000 I -        [conn4] end connection 10.0.0.1:57137 (2 connections now open)
+2017-09-04T16:12:04.248+1000 I -        [conn3] end connection 10.0.0.1:57136 (2 connections now open)
+2017-09-04T16:12:07.365+1000 I NETWORK  [thread1] connection accepted from 10.0.0.1:57138 #5 (1 connection now open)
+2017-09-04T16:12:07.365+1000 I NETWORK  [conn5] received client metadata from 10.0.0.1:57138 conn5: { application: { name: "MongoDB Shell" }, driver: { name: "MongoDB Internal Client", version: "3.4.7" }, os: { type: "Darwin", name: "Mac OS X", architecture: "x86_64", version: "16.6.0" } }
+2017-09-04T16:12:13.917+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:13.917+1000 I COMMAND  [conn5] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:19.922+1000 D COMMAND  [conn5] run command test.$cmd { insert: "test", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true }
+2017-09-04T16:12:19.922+1000 D -        [conn5] reloading view catalog for database test
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] create collection test.test {}
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] stored meta data for test.test @ RecordId(4)
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] WiredTigerKVEngine::createRecordStore uri: table:collection-5--873095094229448774 config: type=file,memory_page_max=10m,split_pct=90,leaf_value_max=64MB,checksum=on,block_compressor=snappy,,key_format=q,value_format=u,app_metadata=(formatVersion=1)
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] WiredTigerUtil::checkApplicationMetadataFormatVersion  uri: table:collection-5--873095094229448774 ok range 1 -> 1 current: 1
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] test.test: clearing plan cache - collection info cache reset
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] WiredTigerKVEngine::createSortedDataInterface ident: index-6--873095094229448774 config: type=file,internal_page_max=16k,leaf_page_max=16k,checksum=on,prefix_compression=true,block_compressor=,,,,key_format=u,value_format=u,app_metadata=(formatVersion=8,infoObj={ "v" : 2, "key" : { "_id" : 1 }, "name" : "_id_", "ns" : "test.test" }),
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] create uri: table:index-6--873095094229448774 config: type=file,internal_page_max=16k,leaf_page_max=16k,checksum=on,prefix_compression=true,block_compressor=,,,,key_format=u,value_format=u,app_metadata=(formatVersion=8,infoObj={ "v" : 2, "key" : { "_id" : 1 }, "name" : "_id_", "ns" : "test.test" }),
+2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] WiredTigerUtil::checkApplicationMetadataFormatVersion  uri: table:index-6--873095094229448774 ok range 6 -> 8 current: 8
+2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] test.test: clearing plan cache - collection info cache reset
+2017-09-04T16:12:19.977+1000 D INDEX    [conn5] marking index _id_ as ready in snapshot id 50
+2017-09-04T16:12:19.977+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
+2017-09-04T16:12:19.977+1000 I COMMAND  [conn5] command test.test appName: "MongoDB Shell" command: insert { insert: "test", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 3, w: 3 } }, Database: { acquireCount: { w: 2, W: 1 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_command 55ms
+2017-09-04T16:12:19.979+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:19.980+1000 I COMMAND  [conn5] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:22.712+1000 D COMMAND  [conn5] run command test.$cmd { insert: "test", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true }
+2017-09-04T16:12:22.712+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
+2017-09-04T16:12:22.712+1000 I COMMAND  [conn5] command test.test appName: "MongoDB Shell" command: insert { insert: "test", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:22.715+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:22.715+1000 I COMMAND  [conn5] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:24.707+1000 D COMMAND  [conn5] run command test.$cmd { insert: "test", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true }
+2017-09-04T16:12:24.707+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
+2017-09-04T16:12:24.707+1000 I COMMAND  [conn5] command test.test appName: "MongoDB Shell" command: insert { insert: "test", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:24.708+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:24.708+1000 I COMMAND  [conn5] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:40.866+1000 D COMMAND  [conn5] run command test.$cmd { find: "test", filter: { array.element: 1.0 } }
+2017-09-04T16:12:40.866+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { array.element: 1.0 } sort: {} projection: {}, planSummary: COLLSCAN
+2017-09-04T16:12:40.866+1000 I COMMAND  [conn5] command test.test appName: "MongoDB Shell" command: find { find: "test", filter: { array.element: 1.0 } } planSummary: COLLSCAN keysExamined:0 docsExamined:3 cursorExhausted:1 numYields:0 nreturned:0 reslen:82 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:40.867+1000 D COMMAND  [conn5] run command test.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:40.867+1000 I COMMAND  [conn5] command test.$cmd appName: "MongoDB Shell" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:42.631+1000 D NETWORK  [conn5] SocketException: remote: 10.0.0.1:57138 error: 9001 socket exception [CLOSED] server [10.0.0.1:57138] 
+2017-09-04T16:12:42.631+1000 I -        [conn5] end connection 10.0.0.1:57138 (1 connection now open)
+2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 10.0.0.1:57139 #6 (1 connection now open)
+2017-09-04T16:12:48.001+1000 D COMMAND  [conn7] run command admin.$cmd { ping: 1 }
+2017-09-04T16:12:48.001+1000 I COMMAND  [conn7] command admin.$cmd command: ping { ping: 1 } numYields:0 reslen:37 locks:{} protocol:op_query 0ms
+2017-09-04T16:12:48.001+1000 D NETWORK  [conn6] SocketException: remote: 10.0.0.1:57139 error: 9001 socket exception [CLOSED] server [10.0.0.1:57139] 
+2017-09-04T16:12:48.001+1000 D NETWORK  [conn7] SocketException: remote: 10.0.0.1:57140 error: 9001 socket exception [CLOSED] server [10.0.0.1:57140] 
+2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 10.0.0.1:57139 (2 connections now open)
+2017-09-04T16:12:48.001+1000 I -        [conn7] end connection 10.0.0.1:57140 (2 connections now open)
+2017-09-04T16:12:48.020+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
+2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] closing listening socket: 9
+2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] removing socket file: /tmp/mongodb-27017.sock
+2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T16:12:48.021+1000 D QUERY    [signalProcessingThread] received interrupt request for unknown op: 87  known ops: 
+2017-09-04T16:12:48.021+1000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: admin.system.version
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: local.startup_log
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: test.test
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: _mdb_catalog
+2017-09-04T16:12:48.022+1000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:_mdb_catalog -> { numRecords: 4, dataSize: 1341 }
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:collection-0--873095094229448774 -> { numRecords: 1, dataSize: 1795 }
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:collection-2--873095094229448774 -> { numRecords: 1, dataSize: 59 }
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:collection-5--873095094229448774 -> { numRecords: 3, dataSize: 105 }
+2017-09-04T16:12:48.055+1000 D STORAGE  [WTJournalFlusher] stopping WTJournalFlusher thread
+2017-09-04T16:12:48.216+1000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T16:12:48.217+1000 I CONTROL  [signalProcessingThread] now exiting
+2017-09-04T16:12:48.217+1000 I CONTROL  [signalProcessingThread] shutting down with code:0
+2017-09-04T16:12:48.217+1000 I CONTROL  [initandlisten] shutting down with code:0

--- a/test/sample.ts.log
+++ b/test/sample.ts.log
@@ -1,0 +1,11 @@
+2017-08-25T22:23:49.097+0000 I COMMAND [conn0]
+2017-08-25T22:23:49.007+1000 I COMMAND [conn0]
+2017-09-04T12:07:36.596+1000 D COMMAND  [conn6] run command test.$cmd { find: "test", filter: { key: 1.0 } }
+2017-09-04T12:07:36.596+1000 D QUERY    [conn6] Only one plan is available; it will be run but will not be cached. query: { key: 1.0 } sort: {} projection: {}, planSummary: COLLSCAN
+2017-09-04T12:07:36.596+1000 I COMMAND  [conn6] command test.test appName: "MongoDB Shell" command: find { find: "test", filter: { key: 1.0 } } planSummary: COLLSCAN keysExamined:0 docsExamined:3 cursorExhausted:1 numYields:0 nreturned:1 reslen:118 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_command 0ms
+2017-09-04T12:09:02.206+1000 D COMMAND  [conn7] run command test.$cmd { find: "test", filter: { arr.element: 1.0 } }
+2017-09-04T12:09:02.206+1000 D COMMAND  [conn7] run command test.$cmd { find: "test", filter: { array.element: 1.0 } }
+2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 10.0.0.1:57139 #6 (1 connection now open)
+2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 10.0.0.1:57139 (2 connections now open)
+2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 127.0.0.1:57139 #6 (1 connection now open)
+2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 127.0.0.1:57139 (2 connections now open)

--- a/test/sample_redacted.2.4.log
+++ b/test/sample_redacted.2.4.log
@@ -1,0 +1,47 @@
+Mon Sep  4 15:25:31.160 [initandlisten] MongoDB starting : pid=96748 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+Mon Sep  4 15:25:31.160 [initandlisten] db version v2.4.14
+Mon Sep  4 15:25:31.160 [initandlisten] git version: 05bebf9ab15511a71bfbded684bb226014c0a553
+Mon Sep  4 15:25:31.160 [initandlisten] build info: Darwin sapid.lightcyan.elderberry 10.8.0 Darwin Kernel Version 10.8.0: Tue Jun  7 16:32:41 PDT 2011; root:xnu-1504.15.3~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+Mon Sep  4 15:25:31.160 [initandlisten] allocator: system
+Mon Sep  4 15:25:31.160 [initandlisten] options: { dbpath: "113a0be68e2aab292bc66b585693e3af", fork: true, logappend: true, logpath: "7e9a35332969c662744a42ce0bb4dc2a", port: 27017 }
+Mon Sep  4 15:25:31.161 [initandlisten] journal dir=/data/db/journal
+Mon Sep  4 15:25:31.161 [initandlisten] recover : no journal files present, no recovery needed
+Mon Sep  4 15:25:31.170 [initandlisten] allocating new ns file /lime.chili.pepper filling with zeroes...
+Mon Sep  4 15:25:31.214 [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
+Mon Sep  4 15:25:31.214 [FileAllocator] creating directory /data/db/_tmp
+Mon Sep  4 15:25:31.311 [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.096 secs
+Mon Sep  4 15:25:31.328 [initandlisten] command local.$cmd command: { create: "14fbee31fc08f4add97cdbf9fd5b19d0", size: 10485760, capped: true } ntoreturn:1 keyUpdates:0  reslen:37 157ms
+Mon Sep  4 15:25:31.330 [websvr] admin web console waiting for connections on port 28017
+Mon Sep  4 15:25:31.330 [initandlisten] waiting for connections on port 27017
+Mon Sep  4 15:25:31.680 [initandlisten] connection accepted from 127.0.0.1:56846 #1 (1 connection now open)
+Mon Sep  4 15:25:32.185 [conn1] end connection 127.0.0.1:56846 (3 connections now open)
+Mon Sep  4 15:26:00.562 [conn6] allocating new ns file /cadetblue.chili.pepper filling with zeroes...
+Mon Sep  4 15:26:00.593 [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
+Mon Sep  4 15:26:00.695 [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.101 secs
+Mon Sep  4 15:26:00.713 [FileAllocator] allocating new datafile /data/db/test.1, filling with zeroes...
+Mon Sep  4 15:26:00.714 [conn6] build index darkmagenta.darkmagenta { _id: 1 }
+Mon Sep  4 15:26:00.755 [conn6] build index done.  scanned 0 total records. 0.04 secs
+Mon Sep  4 15:26:00.755 [conn6] insert darkmagenta.darkmagenta ninserted:1 keyUpdates:0 locks(micros) w:192860 192ms
+Mon Sep  4 15:26:00.926 [FileAllocator] done allocating datafile /data/db/test.1, size: 128MB,  took 0.212 secs
+Mon Sep  4 15:26:38.142 [conn6] creating profile collection: darkmagenta.papayawhip.melon
+Mon Sep  4 15:26:48.923 [conn6] query darkmagenta.darkmagenta query: { key: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:215 nreturned:0 reslen:20 0ms
+Mon Sep  4 15:27:18.286 [conn6] query darkmagenta.darkmagenta query: { darkorchid.orange: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:138 nreturned:0 reslen:20 0ms
+Mon Sep  4 15:27:22.462 [conn6] end connection 127.0.0.1:56852 (0 connections now open)
+Mon Sep  4 15:27:27.149 [conn8] command admin.$cmd command: { ping: 1 } ntoreturn:1 keyUpdates:0  reslen:37 0ms
+Mon Sep  4 15:27:27.170 [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+Mon Sep  4 15:27:27.171 [signalProcessingThread] now exiting
+Mon Sep  4 15:27:27.171 dbexit:
+Mon Sep  4 15:27:27.171 [signalProcessingThread] shutdown: going to close listening sockets...
+Mon Sep  4 15:27:27.171 [signalProcessingThread] closing listening socket: 10
+Mon Sep  4 15:27:27.172 [signalProcessingThread] removing socket file: /whitesmoke.marion.berry
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: going to flush diaglog...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: going to close sockets...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: waiting for fs preallocator...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: lock for final commit...
+Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: final commit...
+Mon Sep  4 15:27:27.180 [signalProcessingThread] shutdown: closing all files...
+Mon Sep  4 15:27:27.180 [signalProcessingThread] closeAllFiles() finished
+Mon Sep  4 15:27:27.180 [signalProcessingThread] journalCleanup...
+Mon Sep  4 15:27:27.180 [signalProcessingThread] removeJournalFiles
+Mon Sep  4 15:27:27.181 [signalProcessingThread] shutdown: removing fs lock...
+Mon Sep  4 15:27:27.181 dbexit: really exiting now

--- a/test/sample_redacted.2.4.log
+++ b/test/sample_redacted.2.4.log
@@ -1,12 +1,12 @@
-Mon Sep  4 15:25:31.160 [initandlisten] MongoDB starting : pid=96748 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+Mon Sep  4 15:25:31.160 [initandlisten] MongoDB starting : pid=96748 port=27017 dbpath=/data/db 64-bit sandybrown.pear
 Mon Sep  4 15:25:31.160 [initandlisten] db version v2.4.14
 Mon Sep  4 15:25:31.160 [initandlisten] git version: 05bebf9ab15511a71bfbded684bb226014c0a553
-Mon Sep  4 15:25:31.160 [initandlisten] build info: Darwin sapid.lightcyan.elderberry 10.8.0 Darwin Kernel Version 10.8.0: Tue Jun  7 16:32:41 PDT 2011; root:xnu-1504.15.3~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+Mon Sep  4 15:25:31.160 [initandlisten] build info: Darwin hot.darkturquoise.marion.berry 10.8.0 Darwin Kernel Version 10.8.0: Tue Jun  7 16:32:41 PDT 2011; root:xnu-1504.15.3~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
 Mon Sep  4 15:25:31.160 [initandlisten] allocator: system
 Mon Sep  4 15:25:31.160 [initandlisten] options: { dbpath: "113a0be68e2aab292bc66b585693e3af", fork: true, logappend: true, logpath: "7e9a35332969c662744a42ce0bb4dc2a", port: 27017 }
 Mon Sep  4 15:25:31.161 [initandlisten] journal dir=/data/db/journal
 Mon Sep  4 15:25:31.161 [initandlisten] recover : no journal files present, no recovery needed
-Mon Sep  4 15:25:31.170 [initandlisten] allocating new ns file /lime.chili.pepper filling with zeroes...
+Mon Sep  4 15:25:31.170 [initandlisten] allocating new ns file /indigo.persimmon filling with zeroes...
 Mon Sep  4 15:25:31.214 [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
 Mon Sep  4 15:25:31.214 [FileAllocator] creating directory /data/db/_tmp
 Mon Sep  4 15:25:31.311 [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.096 secs
@@ -15,17 +15,17 @@ Mon Sep  4 15:25:31.330 [websvr] admin web console waiting for connections on po
 Mon Sep  4 15:25:31.330 [initandlisten] waiting for connections on port 27017
 Mon Sep  4 15:25:31.680 [initandlisten] connection accepted from 127.0.0.1:56846 #1 (1 connection now open)
 Mon Sep  4 15:25:32.185 [conn1] end connection 127.0.0.1:56846 (3 connections now open)
-Mon Sep  4 15:26:00.562 [conn6] allocating new ns file /cadetblue.chili.pepper filling with zeroes...
+Mon Sep  4 15:26:00.562 [conn6] allocating new ns file /firebrick.persimmon filling with zeroes...
 Mon Sep  4 15:26:00.593 [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
 Mon Sep  4 15:26:00.695 [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.101 secs
 Mon Sep  4 15:26:00.713 [FileAllocator] allocating new datafile /data/db/test.1, filling with zeroes...
-Mon Sep  4 15:26:00.714 [conn6] build index darkmagenta.darkmagenta { _id: 1 }
+Mon Sep  4 15:26:00.714 [conn6] build index mediumaquamarine.mediumaquamarine { _id: 1 }
 Mon Sep  4 15:26:00.755 [conn6] build index done.  scanned 0 total records. 0.04 secs
-Mon Sep  4 15:26:00.755 [conn6] insert darkmagenta.darkmagenta ninserted:1 keyUpdates:0 locks(micros) w:192860 192ms
+Mon Sep  4 15:26:00.755 [conn6] insert mediumaquamarine.mediumaquamarine ninserted:1 keyUpdates:0 locks(micros) w:192860 192ms
 Mon Sep  4 15:26:00.926 [FileAllocator] done allocating datafile /data/db/test.1, size: 128MB,  took 0.212 secs
-Mon Sep  4 15:26:38.142 [conn6] creating profile collection: darkmagenta.papayawhip.melon
-Mon Sep  4 15:26:48.923 [conn6] query darkmagenta.darkmagenta query: { key: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:215 nreturned:0 reslen:20 0ms
-Mon Sep  4 15:27:18.286 [conn6] query darkmagenta.darkmagenta query: { darkorchid.orange: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:138 nreturned:0 reslen:20 0ms
+Mon Sep  4 15:26:38.142 [conn6] creating profile collection: mediumaquamarine.mediumslateblue.eggplant
+Mon Sep  4 15:26:48.923 [conn6] query mediumaquamarine.mediumaquamarine query: { key: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:215 nreturned:0 reslen:20 0ms
+Mon Sep  4 15:27:18.286 [conn6] query mediumaquamarine.mediumaquamarine query: { floralwhite.chili.pepper: 1.0 } ntoreturn:0 ntoskip:0 nscanned:3 keyUpdates:0 locks(micros) r:138 nreturned:0 reslen:20 0ms
 Mon Sep  4 15:27:22.462 [conn6] end connection 127.0.0.1:56852 (0 connections now open)
 Mon Sep  4 15:27:27.149 [conn8] command admin.$cmd command: { ping: 1 } ntoreturn:1 keyUpdates:0  reslen:37 0ms
 Mon Sep  4 15:27:27.170 [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
@@ -33,7 +33,7 @@ Mon Sep  4 15:27:27.171 [signalProcessingThread] now exiting
 Mon Sep  4 15:27:27.171 dbexit:
 Mon Sep  4 15:27:27.171 [signalProcessingThread] shutdown: going to close listening sockets...
 Mon Sep  4 15:27:27.171 [signalProcessingThread] closing listening socket: 10
-Mon Sep  4 15:27:27.172 [signalProcessingThread] removing socket file: /whitesmoke.marion.berry
+Mon Sep  4 15:27:27.172 [signalProcessingThread] removing socket file: /slategray.papaya
 Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: going to flush diaglog...
 Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: going to close sockets...
 Mon Sep  4 15:27:27.172 [signalProcessingThread] shutdown: waiting for fs preallocator...

--- a/test/sample_redacted.2.6.log
+++ b/test/sample_redacted.2.6.log
@@ -1,12 +1,12 @@
-2017-09-04T15:53:44.521+1000 [initandlisten] MongoDB starting : pid=98141 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+2017-09-04T15:53:44.521+1000 [initandlisten] MongoDB starting : pid=98141 port=27017 dbpath=/data/db 64-bit sandybrown.pear
 2017-09-04T15:53:44.521+1000 [initandlisten] db version v2.6.12
 2017-09-04T15:53:44.521+1000 [initandlisten] git version: d73c92b1c85703828b55c2916a5dd4ad46535f6a
-2017-09-04T15:53:44.521+1000 [initandlisten] build info: Darwin sapid.large.darkturquoise.honeydew 12.5.0 Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47 PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+2017-09-04T15:53:44.521+1000 [initandlisten] build info: Darwin hot.famous.lightseagreen.jambul 12.5.0 Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47 PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
 2017-09-04T15:53:44.521+1000 [initandlisten] allocator: system
 2017-09-04T15:53:44.521+1000 [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "113a0be68e2aab292bc66b585693e3af" }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
 2017-09-04T15:53:44.522+1000 [initandlisten] journal dir=/data/db/journal
 2017-09-04T15:53:44.523+1000 [initandlisten] recover : no journal files present, no recovery needed
-2017-09-04T15:53:44.535+1000 [initandlisten] allocating new ns file /palegoldenrod.blueberry filling with zeroes...
+2017-09-04T15:53:44.535+1000 [initandlisten] allocating new ns file /pink.goji.berry filling with zeroes...
 2017-09-04T15:53:44.565+1000 [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
 2017-09-04T15:53:44.565+1000 [FileAllocator] creating directory /data/db/_tmp
 2017-09-04T15:53:44.679+1000 [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.112 secs
@@ -25,28 +25,28 @@
 2017-09-04T15:53:49.531+1000 [initandlisten] connection accepted from 127.0.0.1:57017 #5 (1 connection now open)
 2017-09-04T15:54:06.065+1000 [conn5] end connection 127.0.0.1:57017 (0 connections now open)
 2017-09-04T15:54:08.781+1000 [initandlisten] connection accepted from 127.0.0.1:57019 #6 (1 connection now open)
-2017-09-04T15:54:13.452+1000 [conn6] creating profile collection: smelly.darkmagenta.miracle.fruit
-2017-09-04T15:54:13.453+1000 [conn6] allocating new ns file /darkorchid.blueberry filling with zeroes...
+2017-09-04T15:54:13.452+1000 [conn6] creating profile collection: leathery.mediumaquamarine.salal.berry
+2017-09-04T15:54:13.453+1000 [conn6] allocating new ns file /lightsalmon.goji.berry filling with zeroes...
 2017-09-04T15:54:13.499+1000 [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
 2017-09-04T15:54:13.596+1000 [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.097 secs
-2017-09-04T15:54:13.602+1000 [conn6] command smelly.$cmd command: profile { profile: 2.0, slowms: -1.0 } keyUpdates:0 numYields:0 locks(micros) w:149813 reslen:58 149ms
-2017-09-04T15:54:13.605+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:13.602+1000 [conn6] command leathery.$cmd command: profile { profile: 2.0, slowms: -1.0 } keyUpdates:0 numYields:0 locks(micros) w:149813 reslen:58 149ms
+2017-09-04T15:54:13.605+1000 [conn6] command leathery.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
 2017-09-04T15:54:20.630+1000 [conn6] command admin.$cmd command: isMaster { isMaster: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
-2017-09-04T15:54:20.635+1000 [conn6] build index on: smelly.smelly properties: { v: 1, key: { _id: 1 }, name: "ecd619ef9879c9ed846ac73b2aa533c7", ns: "dbb3565f7116ced1ad598bb12d6cd05e" }
+2017-09-04T15:54:20.635+1000 [conn6] build index on: leathery.leathery properties: { v: 1, key: { _id: 1 }, name: "ecd619ef9879c9ed846ac73b2aa533c7", ns: "dbb3565f7116ced1ad598bb12d6cd05e" }
 2017-09-04T15:54:20.635+1000 [conn6] 	 added index to empty collection
-2017-09-04T15:54:20.635+1000 [conn6] insert smelly.smelly query: { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:2561 2ms
-2017-09-04T15:54:20.636+1000 [conn6] command smelly.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:228 reslen:40 3ms
-2017-09-04T15:54:20.637+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
-2017-09-04T15:54:21.929+1000 [conn6] insert smelly.smelly query: { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:119 0ms
-2017-09-04T15:54:21.930+1000 [conn6] command smelly.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:423 reslen:40 0ms
-2017-09-04T15:54:21.931+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
-2017-09-04T15:54:23.163+1000 [conn6] insert smelly.smelly query: { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:35 0ms
-2017-09-04T15:54:23.163+1000 [conn6] command smelly.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:402 reslen:40 0ms
-2017-09-04T15:54:23.164+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
-2017-09-04T15:54:29.589+1000 [conn6] query smelly.smelly query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:1046 nreturned:1 reslen:55 1ms
-2017-09-04T15:54:29.590+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
-2017-09-04T15:54:34.580+1000 [conn6] query smelly.smelly query: { mistyrose.clementine: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:112 nreturned:0 reslen:20 0ms
-2017-09-04T15:54:34.581+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:20.635+1000 [conn6] insert leathery.leathery query: { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:2561 2ms
+2017-09-04T15:54:20.636+1000 [conn6] command leathery.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:228 reslen:40 3ms
+2017-09-04T15:54:20.637+1000 [conn6] command leathery.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:21.929+1000 [conn6] insert leathery.leathery query: { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:119 0ms
+2017-09-04T15:54:21.930+1000 [conn6] command leathery.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:423 reslen:40 0ms
+2017-09-04T15:54:21.931+1000 [conn6] command leathery.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:23.163+1000 [conn6] insert leathery.leathery query: { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:35 0ms
+2017-09-04T15:54:23.163+1000 [conn6] command leathery.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:402 reslen:40 0ms
+2017-09-04T15:54:23.164+1000 [conn6] command leathery.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:29.589+1000 [conn6] query leathery.leathery query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:1046 nreturned:1 reslen:55 1ms
+2017-09-04T15:54:29.590+1000 [conn6] command leathery.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:34.580+1000 [conn6] query leathery.leathery query: { lime.apricot: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:112 nreturned:0 reslen:20 0ms
+2017-09-04T15:54:34.581+1000 [conn6] command leathery.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
 2017-09-04T15:54:35.837+1000 [conn6] end connection 127.0.0.1:57019 (0 connections now open)
 2017-09-04T15:54:39.491+1000 [initandlisten] connection accepted from 127.0.0.1:57020 #7 (1 connection now open)
 2017-09-04T15:54:39.495+1000 [initandlisten] connection accepted from 127.0.0.1:57021 #8 (2 connections now open)
@@ -59,7 +59,7 @@
 2017-09-04T15:54:39.516+1000 [signalProcessingThread] shutdown: going to close listening sockets...
 2017-09-04T15:54:39.516+1000 [signalProcessingThread] closing listening socket: 9
 2017-09-04T15:54:39.516+1000 [signalProcessingThread] closing listening socket: 10
-2017-09-04T15:54:39.517+1000 [signalProcessingThread] removing socket file: /darkgoldenrod.coconut
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] removing socket file: /indianred.pomelo
 2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: going to flush diaglog...
 2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: going to close sockets...
 2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: waiting for fs preallocator...

--- a/test/sample_redacted.2.6.log
+++ b/test/sample_redacted.2.6.log
@@ -1,0 +1,73 @@
+2017-09-04T15:53:44.521+1000 [initandlisten] MongoDB starting : pid=98141 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+2017-09-04T15:53:44.521+1000 [initandlisten] db version v2.6.12
+2017-09-04T15:53:44.521+1000 [initandlisten] git version: d73c92b1c85703828b55c2916a5dd4ad46535f6a
+2017-09-04T15:53:44.521+1000 [initandlisten] build info: Darwin sapid.large.darkturquoise.honeydew 12.5.0 Darwin Kernel Version 12.5.0: Sun Sep 29 13:33:47 PDT 2013; root:xnu-2050.48.12~1/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+2017-09-04T15:53:44.521+1000 [initandlisten] allocator: system
+2017-09-04T15:53:44.521+1000 [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "113a0be68e2aab292bc66b585693e3af" }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
+2017-09-04T15:53:44.522+1000 [initandlisten] journal dir=/data/db/journal
+2017-09-04T15:53:44.523+1000 [initandlisten] recover : no journal files present, no recovery needed
+2017-09-04T15:53:44.535+1000 [initandlisten] allocating new ns file /palegoldenrod.blueberry filling with zeroes...
+2017-09-04T15:53:44.565+1000 [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
+2017-09-04T15:53:44.565+1000 [FileAllocator] creating directory /data/db/_tmp
+2017-09-04T15:53:44.679+1000 [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.112 secs
+2017-09-04T15:53:44.700+1000 [initandlisten] build index on: local.startup_log properties: { v: 1, key: { _id: 1 }, name: "ecd619ef9879c9ed846ac73b2aa533c7", ns: "2a79628e80fbb769531433a02115576e" }
+2017-09-04T15:53:44.701+1000 [initandlisten] 	 added index to empty collection
+2017-09-04T15:53:44.701+1000 [initandlisten] command local.$cmd command: create { create: "14fbee31fc08f4add97cdbf9fd5b19d0", size: 10485760, capped: true } ntoreturn:1 keyUpdates:0 numYields:0  reslen:37 166ms
+2017-09-04T15:53:44.702+1000 [initandlisten] waiting for connections on port 27017
+2017-09-04T15:53:44.702+1000 [initandlisten] connection accepted from 127.0.0.1:57011 #1 (1 connection now open)
+2017-09-04T15:53:44.705+1000 [initandlisten] connection accepted from 127.0.0.1:57013 #2 (2 connections now open)
+2017-09-04T15:53:44.707+1000 [conn1] end connection 127.0.0.1:57011 (1 connection now open)
+2017-09-04T15:53:44.707+1000 [conn2] end connection 127.0.0.1:57013 (1 connection now open)
+2017-09-04T15:53:44.708+1000 [initandlisten] connection accepted from 127.0.0.1:57014 #3 (1 connection now open)
+2017-09-04T15:53:44.710+1000 [initandlisten] connection accepted from 127.0.0.1:57015 #4 (2 connections now open)
+2017-09-04T15:53:44.711+1000 [conn4] end connection 127.0.0.1:57015 (1 connection now open)
+2017-09-04T15:53:44.711+1000 [conn3] end connection 127.0.0.1:57014 (1 connection now open)
+2017-09-04T15:53:49.531+1000 [initandlisten] connection accepted from 127.0.0.1:57017 #5 (1 connection now open)
+2017-09-04T15:54:06.065+1000 [conn5] end connection 127.0.0.1:57017 (0 connections now open)
+2017-09-04T15:54:08.781+1000 [initandlisten] connection accepted from 127.0.0.1:57019 #6 (1 connection now open)
+2017-09-04T15:54:13.452+1000 [conn6] creating profile collection: smelly.darkmagenta.miracle.fruit
+2017-09-04T15:54:13.453+1000 [conn6] allocating new ns file /darkorchid.blueberry filling with zeroes...
+2017-09-04T15:54:13.499+1000 [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
+2017-09-04T15:54:13.596+1000 [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.097 secs
+2017-09-04T15:54:13.602+1000 [conn6] command smelly.$cmd command: profile { profile: 2.0, slowms: -1.0 } keyUpdates:0 numYields:0 locks(micros) w:149813 reslen:58 149ms
+2017-09-04T15:54:13.605+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:20.630+1000 [conn6] command admin.$cmd command: isMaster { isMaster: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:20.635+1000 [conn6] build index on: smelly.smelly properties: { v: 1, key: { _id: 1 }, name: "ecd619ef9879c9ed846ac73b2aa533c7", ns: "dbb3565f7116ced1ad598bb12d6cd05e" }
+2017-09-04T15:54:20.635+1000 [conn6] 	 added index to empty collection
+2017-09-04T15:54:20.635+1000 [conn6] insert smelly.smelly query: { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:2561 2ms
+2017-09-04T15:54:20.636+1000 [conn6] command smelly.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8c9a7d895b81bf6052'), key: 1.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:228 reslen:40 3ms
+2017-09-04T15:54:20.637+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:21.929+1000 [conn6] insert smelly.smelly query: { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:119 0ms
+2017-09-04T15:54:21.930+1000 [conn6] command smelly.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8d9a7d895b81bf6053'), key: 2.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:423 reslen:40 0ms
+2017-09-04T15:54:21.931+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:23.163+1000 [conn6] insert smelly.smelly query: { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ninserted:1 keyUpdates:0 numYields:0 locks(micros) w:35 0ms
+2017-09-04T15:54:23.163+1000 [conn6] command smelly.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acea8f9a7d895b81bf6054'), key: 3.0 } ], ordered: true } keyUpdates:0 numYields:0 locks(micros) w:402 reslen:40 0ms
+2017-09-04T15:54:23.164+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:29.589+1000 [conn6] query smelly.smelly query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:1046 nreturned:1 reslen:55 1ms
+2017-09-04T15:54:29.590+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:34.580+1000 [conn6] query smelly.smelly query: { mistyrose.clementine: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:3 nscannedObjects:3 keyUpdates:0 numYields:0 locks(micros) r:112 nreturned:0 reslen:20 0ms
+2017-09-04T15:54:34.581+1000 [conn6] command smelly.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 numYields:0  reslen:178 0ms
+2017-09-04T15:54:35.837+1000 [conn6] end connection 127.0.0.1:57019 (0 connections now open)
+2017-09-04T15:54:39.491+1000 [initandlisten] connection accepted from 127.0.0.1:57020 #7 (1 connection now open)
+2017-09-04T15:54:39.495+1000 [initandlisten] connection accepted from 127.0.0.1:57021 #8 (2 connections now open)
+2017-09-04T15:54:39.496+1000 [conn8] command admin.$cmd command: ping { ping: 1 } keyUpdates:0 numYields:0  reslen:37 0ms
+2017-09-04T15:54:39.496+1000 [conn7] end connection 127.0.0.1:57020 (1 connection now open)
+2017-09-04T15:54:39.496+1000 [conn8] end connection 127.0.0.1:57021 (1 connection now open)
+2017-09-04T15:54:39.515+1000 [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] now exiting
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] dbexit:
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] closing listening socket: 9
+2017-09-04T15:54:39.516+1000 [signalProcessingThread] closing listening socket: 10
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] removing socket file: /darkgoldenrod.coconut
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: going to close sockets...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: waiting for fs preallocator...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: lock for final commit...
+2017-09-04T15:54:39.517+1000 [signalProcessingThread] shutdown: final commit...
+2017-09-04T15:54:39.526+1000 [signalProcessingThread] shutdown: closing all files...
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] closeAllFiles() finished
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] journalCleanup...
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] removeJournalFiles
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T15:54:39.527+1000 [signalProcessingThread] dbexit: really exiting now

--- a/test/sample_redacted.3.0.log
+++ b/test/sample_redacted.3.0.log
@@ -1,14 +1,14 @@
-2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] MongoDB starting : pid=98413 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] MongoDB starting : pid=98413 port=27017 dbpath=/data/db 64-bit sandybrown.pear
 2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] db version v3.0.15
 2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] git version: b8ff507269c382bc100fc52f75f48d54cd42ec3b
-2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] build info: Darwin sapid.large.darkturquoise.honeydew 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] build info: Darwin hot.famous.lightseagreen.jambul 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
 2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] allocator: system
 2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "113a0be68e2aab292bc66b585693e3af" }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
 2017-09-04T15:59:46.850+1000 I JOURNAL  [initandlisten] journal dir=/data/db/journal
 2017-09-04T15:59:46.851+1000 I JOURNAL  [initandlisten] recover : no journal files present, no recovery needed
 2017-09-04T15:59:46.863+1000 I JOURNAL  [durability] Durability thread started
 2017-09-04T15:59:46.863+1000 I JOURNAL  [journal writer] Journal writer thread started
-2017-09-04T15:59:46.867+1000 I INDEX    [initandlisten] allocating new ns file /palegoldenrod.blueberry filling with zeroes...
+2017-09-04T15:59:46.867+1000 I INDEX    [initandlisten] allocating new ns file /pink.goji.berry filling with zeroes...
 2017-09-04T15:59:46.911+1000 I STORAGE  [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
 2017-09-04T15:59:46.912+1000 I STORAGE  [FileAllocator] creating directory /data/db/_tmp
 2017-09-04T15:59:47.038+1000 I STORAGE  [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.125 secs
@@ -22,12 +22,12 @@
 2017-09-04T15:59:47.207+1000 I NETWORK  [conn3] end connection 127.0.0.1:57051 (1 connection now open)
 2017-09-04T15:59:47.207+1000 I NETWORK  [conn4] end connection 127.0.0.1:57052 (1 connection now open)
 2017-09-04T15:59:53.146+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57055 #5 (1 connection now open)
-2017-09-04T16:00:01.638+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:00:01.638+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:01.638+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:01.638+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
 2017-09-04T16:00:08.664+1000 D COMMAND  [conn5] run command admin.$cmd { isMaster: 1.0 }
 2017-09-04T16:00:08.664+1000 I COMMAND  [conn5] command admin.$cmd command: isMaster { isMaster: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
-2017-09-04T16:00:08.667+1000 D COMMAND  [conn5] run command peachpuff.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true }
-2017-09-04T16:00:08.668+1000 I INDEX    [conn5] allocating new ns file /darkorchid.blueberry filling with zeroes...
+2017-09-04T16:00:08.667+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true }
+2017-09-04T16:00:08.668+1000 I INDEX    [conn5] allocating new ns file /lightsalmon.goji.berry filling with zeroes...
 2017-09-04T16:00:08.726+1000 I STORAGE  [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
 2017-09-04T16:00:08.904+1000 I STORAGE  [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.177 secs
 2017-09-04T16:00:08.924+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
@@ -36,42 +36,42 @@
 2017-09-04T16:00:08.927+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:4096 fromFreeList: 0 eloc: 0:4000
 2017-09-04T16:00:08.927+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
 2017-09-04T16:00:08.927+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
-2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] peachpuff.papayawhip.melon: clearing plan cache - collection info cache reset
-2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] peachpuff.papayawhip.pomegranate: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] lightgoldenrodyellow.mediumslateblue.eggplant: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] lightgoldenrodyellow.mediumslateblue.pomegranate: clearing plan cache - collection info cache reset
 2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:8192 fromFreeList: 0 eloc: 0:5000
-2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] peachpuff.peachpuff: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] lightgoldenrodyellow.lightgoldenrodyellow: clearing plan cache - collection info cache reset
 2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] allocating new extent
 2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:8192 fromFreeList: 0 eloc: 0:7000
 2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] allocating new extent
 2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:131072 fromFreeList: 0 eloc: 0:9000
-2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] peachpuff.peachpuff: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] lightgoldenrodyellow.lightgoldenrodyellow: clearing plan cache - collection info cache reset
 2017-09-04T16:00:08.936+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
 2017-09-04T16:00:08.936+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
 2017-09-04T16:00:08.937+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
 2017-09-04T16:00:08.937+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
-2017-09-04T16:00:08.937+1000 I WRITE    [conn5] insert peachpuff.peachpuff query: { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
-2017-09-04T16:00:08.937+1000 I COMMAND  [conn5] command peachpuff.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
-2017-09-04T16:00:08.939+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:00:08.939+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
-2017-09-04T16:00:10.205+1000 D COMMAND  [conn5] run command peachpuff.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true }
+2017-09-04T16:00:08.937+1000 I WRITE    [conn5] insert lightgoldenrodyellow.lightgoldenrodyellow query: { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
+2017-09-04T16:00:08.937+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
+2017-09-04T16:00:08.939+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:08.939+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:10.205+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true }
 2017-09-04T16:00:10.205+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
 2017-09-04T16:00:10.206+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
-2017-09-04T16:00:10.206+1000 I WRITE    [conn5] insert peachpuff.peachpuff query: { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
-2017-09-04T16:00:10.206+1000 I COMMAND  [conn5] command peachpuff.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
-2017-09-04T16:00:10.207+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:00:10.207+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
-2017-09-04T16:00:11.569+1000 D COMMAND  [conn5] run command peachpuff.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true }
+2017-09-04T16:00:10.206+1000 I WRITE    [conn5] insert lightgoldenrodyellow.lightgoldenrodyellow query: { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:10.206+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:10.207+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:10.207+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:11.569+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true }
 2017-09-04T16:00:11.570+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
 2017-09-04T16:00:11.570+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
-2017-09-04T16:00:11.570+1000 I WRITE    [conn5] insert peachpuff.peachpuff query: { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
-2017-09-04T16:00:11.570+1000 I COMMAND  [conn5] command peachpuff.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
-2017-09-04T16:00:11.571+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:00:11.571+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:11.570+1000 I WRITE    [conn5] insert lightgoldenrodyellow.lightgoldenrodyellow query: { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:11.570+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:11.571+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:11.571+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
 2017-09-04T16:00:17.402+1000 D QUERY    [conn5] Running query: query: { key: 1.0 } sort: {} projection: {} skip: 0 limit: 0
 2017-09-04T16:00:17.404+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { key: 1.0 } sort: {} projection: {} skip: 0 limit: 0, planSummary: COLLSCAN
-2017-09-04T16:00:17.405+1000 I COMMAND  [conn5] query peachpuff.peachpuff query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:3 keyUpdates:0 writeConflicts:0 numYields:0 nreturned:1 reslen:55 locks:{ Global: { acquireCount: { r: 2 } }, MMAPV1Journal: { acquireCount: { r: 1 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { R: 1 } } } 3ms
-2017-09-04T16:00:17.406+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:00:17.406+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:17.405+1000 I COMMAND  [conn5] query lightgoldenrodyellow.lightgoldenrodyellow query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:3 keyUpdates:0 writeConflicts:0 numYields:0 nreturned:1 reslen:55 locks:{ Global: { acquireCount: { r: 2 } }, MMAPV1Journal: { acquireCount: { r: 1 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { R: 1 } } } 3ms
+2017-09-04T16:00:17.406+1000 D COMMAND  [conn5] run command lightgoldenrodyellow.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:17.406+1000 I COMMAND  [conn5] command lightgoldenrodyellow.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
 2017-09-04T16:00:23.932+1000 D NETWORK  [conn5] SocketException: remote: 127.0.0.1:57055 error: 9001 socket exception [CLOSED] server [127.0.0.1:57055]
 2017-09-04T16:00:23.932+1000 I NETWORK  [conn5] end connection 127.0.0.1:57055 (0 connections now open)
 2017-09-04T16:00:26.731+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57058 #6 (1 connection now open)
@@ -87,7 +87,7 @@
 2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
 2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] closing listening socket: 7
 2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
-2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] removing socket file: /black.jambul
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] removing socket file: /fuchsia.western.raspberry
 2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
 2017-09-04T16:00:26.757+1000 I NETWORK  [signalProcessingThread] shutdown: going to close sockets...
 2017-09-04T16:00:26.757+1000 I STORAGE  [signalProcessingThread] shutdown: waiting for fs preallocator...

--- a/test/sample_redacted.3.0.log
+++ b/test/sample_redacted.3.0.log
@@ -1,0 +1,104 @@
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] MongoDB starting : pid=98413 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] db version v3.0.15
+2017-09-04T15:59:46.839+1000 I CONTROL  [initandlisten] git version: b8ff507269c382bc100fc52f75f48d54cd42ec3b
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] build info: Darwin sapid.large.darkturquoise.honeydew 14.0.0 Darwin Kernel Version 14.0.0: Fri Sep 19 00:26:44 PDT 2014; root:xnu-2782.1.97~2/RELEASE_X86_64 x86_64 BOOST_LIB_VERSION=1_49
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] allocator: system
+2017-09-04T15:59:46.840+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "113a0be68e2aab292bc66b585693e3af" }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
+2017-09-04T15:59:46.850+1000 I JOURNAL  [initandlisten] journal dir=/data/db/journal
+2017-09-04T15:59:46.851+1000 I JOURNAL  [initandlisten] recover : no journal files present, no recovery needed
+2017-09-04T15:59:46.863+1000 I JOURNAL  [durability] Durability thread started
+2017-09-04T15:59:46.863+1000 I JOURNAL  [journal writer] Journal writer thread started
+2017-09-04T15:59:46.867+1000 I INDEX    [initandlisten] allocating new ns file /palegoldenrod.blueberry filling with zeroes...
+2017-09-04T15:59:46.911+1000 I STORAGE  [FileAllocator] allocating new datafile /data/db/local.0, filling with zeroes...
+2017-09-04T15:59:46.912+1000 I STORAGE  [FileAllocator] creating directory /data/db/_tmp
+2017-09-04T15:59:47.038+1000 I STORAGE  [FileAllocator] done allocating datafile /data/db/local.0, size: 64MB,  took 0.125 secs
+2017-09-04T15:59:47.074+1000 I NETWORK  [initandlisten] waiting for connections on port 27017
+2017-09-04T15:59:47.174+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57049 #1 (1 connection now open)
+2017-09-04T15:59:47.200+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57050 #2 (2 connections now open)
+2017-09-04T15:59:47.203+1000 I NETWORK  [conn2] end connection 127.0.0.1:57050 (1 connection now open)
+2017-09-04T15:59:47.203+1000 I NETWORK  [conn1] end connection 127.0.0.1:57049 (1 connection now open)
+2017-09-04T15:59:47.204+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57051 #3 (1 connection now open)
+2017-09-04T15:59:47.206+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57052 #4 (2 connections now open)
+2017-09-04T15:59:47.207+1000 I NETWORK  [conn3] end connection 127.0.0.1:57051 (1 connection now open)
+2017-09-04T15:59:47.207+1000 I NETWORK  [conn4] end connection 127.0.0.1:57052 (1 connection now open)
+2017-09-04T15:59:53.146+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57055 #5 (1 connection now open)
+2017-09-04T16:00:01.638+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:01.638+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:08.664+1000 D COMMAND  [conn5] run command admin.$cmd { isMaster: 1.0 }
+2017-09-04T16:00:08.664+1000 I COMMAND  [conn5] command admin.$cmd command: isMaster { isMaster: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:08.667+1000 D COMMAND  [conn5] run command peachpuff.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true }
+2017-09-04T16:00:08.668+1000 I INDEX    [conn5] allocating new ns file /darkorchid.blueberry filling with zeroes...
+2017-09-04T16:00:08.726+1000 I STORAGE  [FileAllocator] allocating new datafile /data/db/test.0, filling with zeroes...
+2017-09-04T16:00:08.904+1000 I STORAGE  [FileAllocator] done allocating datafile /data/db/test.0, size: 64MB,  took 0.177 secs
+2017-09-04T16:00:08.924+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.924+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.926+1000 D STORAGE  [conn5] allocating new extent
+2017-09-04T16:00:08.927+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:4096 fromFreeList: 0 eloc: 0:4000
+2017-09-04T16:00:08.927+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.927+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] peachpuff.papayawhip.melon: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] peachpuff.papayawhip.pomegranate: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:8192 fromFreeList: 0 eloc: 0:5000
+2017-09-04T16:00:08.934+1000 D STORAGE  [conn5] peachpuff.peachpuff: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] allocating new extent
+2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:8192 fromFreeList: 0 eloc: 0:7000
+2017-09-04T16:00:08.935+1000 D STORAGE  [conn5] allocating new extent
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] MmapV1ExtentManager::allocateExtent desiredSize:131072 fromFreeList: 0 eloc: 0:9000
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5] peachpuff.peachpuff: clearing plan cache - collection info cache reset
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.936+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.937+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:08.937+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:08.937+1000 I WRITE    [conn5] insert peachpuff.peachpuff query: { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
+2017-09-04T16:00:08.937+1000 I COMMAND  [conn5] command peachpuff.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebe810a460065a6b599a'), key: 1.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 2, w: 2 } }, MMAPV1Journal: { acquireCount: { w: 8 }, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 74 } }, Database: { acquireCount: { w: 1, W: 1 } }, Collection: { acquireCount: { W: 1 } }, Metadata: { acquireCount: { W: 4 } } } 269ms
+2017-09-04T16:00:08.939+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:08.939+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:10.205+1000 D COMMAND  [conn5] run command peachpuff.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true }
+2017-09-04T16:00:10.205+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:10.206+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:10.206+1000 I WRITE    [conn5] insert peachpuff.peachpuff query: { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:10.206+1000 I COMMAND  [conn5] command peachpuff.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebea10a460065a6b599b'), key: 2.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:10.207+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:10.207+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:11.569+1000 D COMMAND  [conn5] run command peachpuff.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true }
+2017-09-04T16:00:11.570+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 disk writes
+2017-09-04T16:00:11.570+1000 D STORAGE  [conn5]    ***** ROLLING BACK 0 custom changes
+2017-09-04T16:00:11.570+1000 I WRITE    [conn5] insert peachpuff.peachpuff query: { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ninserted:1 keyUpdates:0 writeConflicts:0 numYields:0 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:11.570+1000 I COMMAND  [conn5] command peachpuff.$cmd command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59acebeb10a460065a6b599c'), key: 3.0 } ], ordered: true } keyUpdates:0 writeConflicts:0 numYields:0 reslen:40 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { W: 1 } } } 0ms
+2017-09-04T16:00:11.571+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:11.571+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:17.402+1000 D QUERY    [conn5] Running query: query: { key: 1.0 } sort: {} projection: {} skip: 0 limit: 0
+2017-09-04T16:00:17.404+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { key: 1.0 } sort: {} projection: {} skip: 0 limit: 0, planSummary: COLLSCAN
+2017-09-04T16:00:17.405+1000 I COMMAND  [conn5] query peachpuff.peachpuff query: { key: 1.0 } planSummary: COLLSCAN ntoreturn:0 ntoskip:0 nscanned:0 nscannedObjects:3 keyUpdates:0 writeConflicts:0 numYields:0 nreturned:1 reslen:55 locks:{ Global: { acquireCount: { r: 2 } }, MMAPV1Journal: { acquireCount: { r: 1 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { R: 1 } } } 3ms
+2017-09-04T16:00:17.406+1000 D COMMAND  [conn5] run command peachpuff.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:00:17.406+1000 I COMMAND  [conn5] command peachpuff.$cmd command: isMaster { isMaster: 1.0, forShell: 1.0 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:178 locks:{} 0ms
+2017-09-04T16:00:23.932+1000 D NETWORK  [conn5] SocketException: remote: 127.0.0.1:57055 error: 9001 socket exception [CLOSED] server [127.0.0.1:57055]
+2017-09-04T16:00:23.932+1000 I NETWORK  [conn5] end connection 127.0.0.1:57055 (0 connections now open)
+2017-09-04T16:00:26.731+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57058 #6 (1 connection now open)
+2017-09-04T16:00:26.734+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57059 #7 (2 connections now open)
+2017-09-04T16:00:26.735+1000 D COMMAND  [conn7] run command admin.$cmd { ping: 1 }
+2017-09-04T16:00:26.736+1000 I COMMAND  [conn7] command admin.$cmd command: ping { ping: 1 } keyUpdates:0 writeConflicts:0 numYields:0 reslen:37 locks:{} 0ms
+2017-09-04T16:00:26.736+1000 D NETWORK  [conn7] SocketException: remote: 127.0.0.1:57059 error: 9001 socket exception [CLOSED] server [127.0.0.1:57059]
+2017-09-04T16:00:26.736+1000 D NETWORK  [conn6] SocketException: remote: 127.0.0.1:57058 error: 9001 socket exception [CLOSED] server [127.0.0.1:57058]
+2017-09-04T16:00:26.736+1000 I NETWORK  [conn7] end connection 127.0.0.1:57059 (1 connection now open)
+2017-09-04T16:00:26.737+1000 I NETWORK  [conn6] end connection 127.0.0.1:57058 (1 connection now open)
+2017-09-04T16:00:26.755+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T16:00:26.755+1000 I CONTROL  [signalProcessingThread] now exiting
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] closing listening socket: 7
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] removing socket file: /black.jambul
+2017-09-04T16:00:26.756+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T16:00:26.757+1000 I NETWORK  [signalProcessingThread] shutdown: going to close sockets...
+2017-09-04T16:00:26.757+1000 I STORAGE  [signalProcessingThread] shutdown: waiting for fs preallocator...
+2017-09-04T16:00:26.757+1000 I STORAGE  [signalProcessingThread] shutdown: final commit...
+2017-09-04T16:00:26.767+1000 I JOURNAL  [signalProcessingThread] journalCleanup...
+2017-09-04T16:00:26.767+1000 I JOURNAL  [signalProcessingThread] removeJournalFiles
+2017-09-04T16:00:26.768+1000 D JOURNAL  [signalProcessingThread] removeJournalFiles end
+2017-09-04T16:00:26.768+1000 I JOURNAL  [signalProcessingThread] Terminating durability thread ...
+2017-09-04T16:00:26.867+1000 I JOURNAL  [journal writer] Journal writer thread stopped
+2017-09-04T16:00:26.867+1000 I JOURNAL  [durability] Durability thread stopped
+2017-09-04T16:00:26.868+1000 I STORAGE  [signalProcessingThread] shutdown: closing all files...
+2017-09-04T16:00:26.869+1000 I STORAGE  [signalProcessingThread] closeAllFiles() finished
+2017-09-04T16:00:26.870+1000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T16:00:26.870+1000 I CONTROL  [signalProcessingThread] dbexit:  rc: 0

--- a/test/sample_redacted.3.2.log
+++ b/test/sample_redacted.3.2.log
@@ -1,4 +1,4 @@
-2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] MongoDB starting : pid=99243 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] MongoDB starting : pid=99243 port=27017 dbpath=/data/db 64-bit sandybrown.pear
 2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] db version v3.2.14
 2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] git version: 92f6668a768ebf294bd4f494c50f48459198e6a3
 2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 0.9.8zh 14 Jan 2016
@@ -9,30 +9,30 @@
 2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten]     target_arch: x86_64
 2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "bbcbafbb897f83b2a2f03b55aa13db1d", wiredTiger: { engineConfig: { cacheSizeGB: 1 } } }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
 2017-09-04T16:07:03.263+1000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=1G,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
-2017-09-04T16:07:04.119+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/olivedrab.lime
+2017-09-04T16:07:04.119+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/khaki.eggplant
 2017-09-04T16:07:04.119+1000 I NETWORK  [HostnameCanonicalizationWorker] Starting hostname canonicalization worker
 2017-09-04T16:07:04.119+1000 I NETWORK  [initandlisten] waiting for connections on port 27017
 2017-09-04T16:07:04.136+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57104 #1 (1 connection now open)
 2017-09-04T16:07:04.170+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57105 #2 (2 connections now open)
-2017-09-04T16:07:04.171+1000 I NETWORK  [conn1] end connection 192.168.67.138:57104 (1 connection now open)
-2017-09-04T16:07:04.171+1000 I NETWORK  [conn2] end connection 192.168.67.138:57105 (1 connection now open)
-2017-09-04T16:07:04.178+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57106 #3 (1 connection now open)
-2017-09-04T16:07:04.180+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57107 #4 (2 connections now open)
-2017-09-04T16:07:04.180+1000 I NETWORK  [conn3] end connection 192.168.67.138:57106 (1 connection now open)
-2017-09-04T16:07:04.180+1000 I NETWORK  [conn4] end connection 192.168.67.138:57107 (1 connection now open)
-2017-09-04T16:07:07.217+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57110 #5 (1 connection now open)
-2017-09-04T16:08:08.159+1000 I NETWORK  [conn5] end connection 192.168.67.138:57110 (0 connections now open)
-2017-09-04T16:08:10.922+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57114 #6 (1 connection now open)
-2017-09-04T16:08:10.926+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57115 #7 (2 connections now open)
-2017-09-04T16:08:10.926+1000 I NETWORK  [conn6] end connection 192.168.67.138:57114 (1 connection now open)
-2017-09-04T16:08:10.926+1000 I NETWORK  [conn7] end connection 192.168.67.138:57115 (1 connection now open)
+2017-09-04T16:07:04.171+1000 I NETWORK  [conn1] end connection 192.168.130.103:57104 (1 connection now open)
+2017-09-04T16:07:04.171+1000 I NETWORK  [conn2] end connection 192.168.130.103:57105 (1 connection now open)
+2017-09-04T16:07:04.178+1000 I NETWORK  [initandlisten] connection accepted from 192.168.130.103:57106 #3 (1 connection now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [initandlisten] connection accepted from 192.168.130.103:57107 #4 (2 connections now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [conn3] end connection 192.168.130.103:57106 (1 connection now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [conn4] end connection 192.168.130.103:57107 (1 connection now open)
+2017-09-04T16:07:07.217+1000 I NETWORK  [initandlisten] connection accepted from 192.168.130.103:57110 #5 (1 connection now open)
+2017-09-04T16:08:08.159+1000 I NETWORK  [conn5] end connection 192.168.130.103:57110 (0 connections now open)
+2017-09-04T16:08:10.922+1000 I NETWORK  [initandlisten] connection accepted from 192.168.130.103:57114 #6 (1 connection now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [initandlisten] connection accepted from 192.168.130.103:57115 #7 (2 connections now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [conn6] end connection 192.168.130.103:57114 (1 connection now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [conn7] end connection 192.168.130.103:57115 (1 connection now open)
 2017-09-04T16:08:10.945+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
 2017-09-04T16:08:10.946+1000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
 2017-09-04T16:08:10.947+1000 I CONTROL  [signalProcessingThread] now exiting
 2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
 2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] closing listening socket: 7
 2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
-2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] removing socket file: /palegoldenrod.blueberry
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] removing socket file: /pink.goji.berry
 2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
 2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] shutdown: going to close sockets...
 2017-09-04T16:08:10.948+1000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down

--- a/test/sample_redacted.3.2.log
+++ b/test/sample_redacted.3.2.log
@@ -1,0 +1,40 @@
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] MongoDB starting : pid=99243 port=27017 dbpath=/data/db 64-bit darkgray.lemon
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] db version v3.2.14
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] git version: 92f6668a768ebf294bd4f494c50f48459198e6a3
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 0.9.8zh 14 Jan 2016
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] allocator: system
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] modules: none
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] build environment:
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten]     distarch: x86_64
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten]     target_arch: x86_64
+2017-09-04T16:07:03.262+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "bbcbafbb897f83b2a2f03b55aa13db1d", wiredTiger: { engineConfig: { cacheSizeGB: 1 } } }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
+2017-09-04T16:07:03.263+1000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=1G,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
+2017-09-04T16:07:04.119+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/olivedrab.lime
+2017-09-04T16:07:04.119+1000 I NETWORK  [HostnameCanonicalizationWorker] Starting hostname canonicalization worker
+2017-09-04T16:07:04.119+1000 I NETWORK  [initandlisten] waiting for connections on port 27017
+2017-09-04T16:07:04.136+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57104 #1 (1 connection now open)
+2017-09-04T16:07:04.170+1000 I NETWORK  [initandlisten] connection accepted from 127.0.0.1:57105 #2 (2 connections now open)
+2017-09-04T16:07:04.171+1000 I NETWORK  [conn1] end connection 192.168.67.138:57104 (1 connection now open)
+2017-09-04T16:07:04.171+1000 I NETWORK  [conn2] end connection 192.168.67.138:57105 (1 connection now open)
+2017-09-04T16:07:04.178+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57106 #3 (1 connection now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57107 #4 (2 connections now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [conn3] end connection 192.168.67.138:57106 (1 connection now open)
+2017-09-04T16:07:04.180+1000 I NETWORK  [conn4] end connection 192.168.67.138:57107 (1 connection now open)
+2017-09-04T16:07:07.217+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57110 #5 (1 connection now open)
+2017-09-04T16:08:08.159+1000 I NETWORK  [conn5] end connection 192.168.67.138:57110 (0 connections now open)
+2017-09-04T16:08:10.922+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57114 #6 (1 connection now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [initandlisten] connection accepted from 192.168.67.138:57115 #7 (2 connections now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [conn6] end connection 192.168.67.138:57114 (1 connection now open)
+2017-09-04T16:08:10.926+1000 I NETWORK  [conn7] end connection 192.168.67.138:57115 (1 connection now open)
+2017-09-04T16:08:10.945+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T16:08:10.946+1000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
+2017-09-04T16:08:10.947+1000 I CONTROL  [signalProcessingThread] now exiting
+2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] closing listening socket: 7
+2017-09-04T16:08:10.947+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] removing socket file: /palegoldenrod.blueberry
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T16:08:10.948+1000 I NETWORK  [signalProcessingThread] shutdown: going to close sockets...
+2017-09-04T16:08:10.948+1000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
+2017-09-04T16:08:11.128+1000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T16:08:11.130+1000 I CONTROL  [signalProcessingThread] dbexit:  rc: 0

--- a/test/sample_redacted.3.4.log
+++ b/test/sample_redacted.3.4.log
@@ -1,0 +1,90 @@
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] MongoDB starting : pid=99463 port=27017 dbpath=/data/db 64-bit host=local
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] db version v3.4.7
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] git version: cf38c1b8a0a8dca4a11737581beafef4fe120bcd
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] OpenSSL version: OpenSSL 0.9.8zh 14 Jan 2016
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] allocator: system
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] modules: none
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] build environment:
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten]     distarch: x86_64
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten]     target_arch: x86_64
+2017-09-04T16:12:03.203+1000 I CONTROL  [initandlisten] options: { net: { port: 27017 }, processManagement: { fork: true }, storage: { dbPath: "113a0be68e2aab292bc66b585693e3af", wiredTiger: { engineConfig: { cacheSizeGB: 1.0 } } }, systemLog: { destination: "46bcb895313c0750321a43b7a47cdc87", logAppend: true, path: "7e9a35332969c662744a42ce0bb4dc2a" } }
+2017-09-04T16:12:03.204+1000 I STORAGE  [initandlisten] wiredtiger_open config: create,cache_size=1024M,session_max=20000,eviction=(threads_min=4,threads_max=4),config_base=false,statistics=(fast),log=(enabled=true,archive=true,path=journal,compressor=snappy),file_manager=(close_idle_time=100000),checkpoint=(wait=60,log_size=2GB),statistics_log=(wait=0),
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten]
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
+2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten]
+2017-09-04T16:12:03.939+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/darkgray.lemon
+2017-09-04T16:12:04.222+1000 I INDEX    [initandlisten] build index on: admin.system.version properties: { v: 2, key: { version: 1 }, name: "bc4a8a865ba4cff1bc4872cd0de8b175", ns: "77b28b92e6540f833e380d9f8b53407d" }
+2017-09-04T16:12:04.222+1000 I INDEX    [initandlisten] 	 building index using bulk method; build may temporarily use up to 500 megabytes of RAM
+2017-09-04T16:12:04.236+1000 I INDEX    [initandlisten] build index done.  scanned 0 total records. 0 secs
+2017-09-04T16:12:04.236+1000 I COMMAND  [initandlisten] setting featureCompatibilityVersion to 3.4
+2017-09-04T16:12:04.236+1000 I NETWORK  [thread1] waiting for connections on port 27017
+2017-09-04T16:12:04.240+1000 I NETWORK  [thread1] connection accepted from 127.0.0.1:57134 #1 (1 connection now open)
+2017-09-04T16:12:04.248+1000 I -        [conn4] end connection 192.168.179.118:57137 (2 connections now open)
+2017-09-04T16:12:04.248+1000 I -        [conn3] end connection 192.168.179.118:57136 (2 connections now open)
+2017-09-04T16:12:07.365+1000 I NETWORK  [thread1] connection accepted from 192.168.179.118:57138 #5 (1 connection now open)
+2017-09-04T16:12:07.365+1000 I NETWORK  [conn5] received client metadata from 192.168.179.118:57138 conn5: { application: { name: "94a622f1747659c540bfa9f105de145f" }, driver: { name: "83c67e6f57c4fa51f4ac1565e74456b9", version: "a28f9918e19547698799858a6d65f46a" }, os: { type: "0ebb1448f597a99a0f73e9da2c2644be", name: "47b6216057388787126f850c1860ea8d", architecture: "270ae8f00c4f8a33677ce5f47a000a44", version: "264d624a1eed6d7aea5472819ab56933" } }
+2017-09-04T16:12:13.917+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:13.917+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:19.922+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true }
+2017-09-04T16:12:19.922+1000 D -        [conn5] reloading view catalog for database test
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] create collection darkturquoise.darkturquoise {}
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] stored meta data for darkturquoise.darkturquoise @ RecordId(4)
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] WiredTigerKVEngine::createRecordStore uri: table:collection-5--873095094229448774 config: type=file,memory_page_max=10m,split_pct=90,leaf_value_max=64MB,checksum=on,block_compressor=snappy,,key_format=q,value_format=u,app_metadata=(formatVersion=1)
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] WiredTigerUtil::checkApplicationMetadataFormatVersion  uri: table:collection-5--873095094229448774 ok range 1 -> 1 current: 1
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] darkturquoise.darkturquoise: clearing plan cache - collection info cache reset
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] WiredTigerKVEngine::createSortedDataInterface ident: index-6--873095094229448774 config: type=file,internal_page_max=16k,leaf_page_max=16k,checksum=on,prefix_compression=true,block_compressor=,,,,key_format=u,value_format=u,app_metadata=(formatVersion=8,infoObj={ "59b943d2fe6aede1820f470ac1e94e1a" : 2, "02ba83662661dcf7d3d3582a9f3e64f0" : { "ba446a583e8ec693391bce36164d9dc7" : 1 }, "984fecde60a13b93d99af5d40c85f9ee" : "ecd619ef9879c9ed846ac73b2aa533c7", "fd3dd255c469e25ec997b6577eb217ec" : "dbb3565f7116ced1ad598bb12d6cd05e" }),
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] create uri: table:index-6--873095094229448774 config: type=file,internal_page_max=16k,leaf_page_max=16k,checksum=on,prefix_compression=true,block_compressor=,,,,key_format=u,value_format=u,app_metadata=(formatVersion=8,infoObj={ "59b943d2fe6aede1820f470ac1e94e1a" : 2, "02ba83662661dcf7d3d3582a9f3e64f0" : { "ba446a583e8ec693391bce36164d9dc7" : 1 }, "984fecde60a13b93d99af5d40c85f9ee" : "ecd619ef9879c9ed846ac73b2aa533c7", "fd3dd255c469e25ec997b6577eb217ec" : "dbb3565f7116ced1ad598bb12d6cd05e" }),
+2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] WiredTigerUtil::checkApplicationMetadataFormatVersion  uri: table:index-6--873095094229448774 ok range 6 -> 8 current: 8
+2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] darkturquoise.darkturquoise: clearing plan cache - collection info cache reset
+2017-09-04T16:12:19.977+1000 D INDEX    [conn5] marking index _id_ as ready in snapshot id 50
+2017-09-04T16:12:19.977+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
+2017-09-04T16:12:19.977+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 3, w: 3 } }, Database: { acquireCount: { w: 2, W: 1 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_command 55ms
+2017-09-04T16:12:19.979+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:19.980+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:22.712+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true }
+2017-09-04T16:12:22.712+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
+2017-09-04T16:12:22.712+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:22.715+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:22.715+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:24.707+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true }
+2017-09-04T16:12:24.707+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
+2017-09-04T16:12:24.707+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:24.708+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:24.708+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:40.866+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { find: "303b5c8988601647873b4ffd247d83cb", filter: { darkcyan.cloudberry: 1.0 } }
+2017-09-04T16:12:40.866+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { darkcyan.cloudberry: 1.0 } sort: {} projection: {}, planSummary: COLLSCAN
+2017-09-04T16:12:40.866+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: find { find: "303b5c8988601647873b4ffd247d83cb", filter: { darkcyan.cloudberry: 1.0 } } planSummary: COLLSCAN keysExamined:0 docsExamined:3 cursorExhausted:1 numYields:0 nreturned:0 reslen:82 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:40.867+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:40.867+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:42.631+1000 D NETWORK  [conn5] SocketException: remote: 192.168.179.118:57138 error: 9001 socket exception [CLOSED] server [192.168.179.118:57138]
+2017-09-04T16:12:42.631+1000 I -        [conn5] end connection 192.168.179.118:57138 (1 connection now open)
+2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 192.168.179.118:57139 #6 (1 connection now open)
+2017-09-04T16:12:48.001+1000 D COMMAND  [conn7] run command admin.$cmd { ping: 1 }
+2017-09-04T16:12:48.001+1000 I COMMAND  [conn7] command admin.$cmd command: ping { ping: 1 } numYields:0 reslen:37 locks:{} protocol:op_query 0ms
+2017-09-04T16:12:48.001+1000 D NETWORK  [conn6] SocketException: remote: 192.168.179.118:57139 error: 9001 socket exception [CLOSED] server [192.168.179.118:57139]
+2017-09-04T16:12:48.001+1000 D NETWORK  [conn7] SocketException: remote: 192.168.179.118:57140 error: 9001 socket exception [CLOSED] server [192.168.179.118:57140]
+2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 192.168.179.118:57139 (2 connections now open)
+2017-09-04T16:12:48.001+1000 I -        [conn7] end connection 192.168.179.118:57140 (2 connections now open)
+2017-09-04T16:12:48.020+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
+2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
+2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
+2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] closing listening socket: 9
+2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] removing socket file: /khaki.tomato
+2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
+2017-09-04T16:12:48.021+1000 D QUERY    [signalProcessingThread] received interrupt request for unknown op: 87  known ops:
+2017-09-04T16:12:48.021+1000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: admin.system.version
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: local.startup_log
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: darkturquoise.darkturquoise
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: _mdb_catalog
+2017-09-04T16:12:48.022+1000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:_mdb_catalog -> { numRecords: 4, dataSize: 1341 }
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:collection-0--873095094229448774 -> { numRecords: 1, dataSize: 1795 }
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:collection-2--873095094229448774 -> { numRecords: 1, dataSize: 59 }
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:collection-5--873095094229448774 -> { numRecords: 3, dataSize: 105 }
+2017-09-04T16:12:48.055+1000 D STORAGE  [WTJournalFlusher] stopping WTJournalFlusher thread
+2017-09-04T16:12:48.216+1000 I STORAGE  [signalProcessingThread] shutdown: removing fs lock...
+2017-09-04T16:12:48.217+1000 I CONTROL  [signalProcessingThread] now exiting
+2017-09-04T16:12:48.217+1000 I CONTROL  [signalProcessingThread] shutting down with code:0
+2017-09-04T16:12:48.217+1000 I CONTROL  [initandlisten] shutting down with code:0

--- a/test/sample_redacted.3.4.log
+++ b/test/sample_redacted.3.4.log
@@ -13,70 +13,70 @@
 2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] ** WARNING: Access control is not enabled for the database.
 2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten] **          Read and write access to data and configuration is unrestricted.
 2017-09-04T16:12:03.815+1000 I CONTROL  [initandlisten]
-2017-09-04T16:12:03.939+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/darkgray.lemon
+2017-09-04T16:12:03.939+1000 I FTDC     [initandlisten] Initializing full-time diagnostic data capture with directory '/sandybrown.pear
 2017-09-04T16:12:04.222+1000 I INDEX    [initandlisten] build index on: admin.system.version properties: { v: 2, key: { version: 1 }, name: "bc4a8a865ba4cff1bc4872cd0de8b175", ns: "77b28b92e6540f833e380d9f8b53407d" }
 2017-09-04T16:12:04.222+1000 I INDEX    [initandlisten] 	 building index using bulk method; build may temporarily use up to 500 megabytes of RAM
 2017-09-04T16:12:04.236+1000 I INDEX    [initandlisten] build index done.  scanned 0 total records. 0 secs
 2017-09-04T16:12:04.236+1000 I COMMAND  [initandlisten] setting featureCompatibilityVersion to 3.4
 2017-09-04T16:12:04.236+1000 I NETWORK  [thread1] waiting for connections on port 27017
 2017-09-04T16:12:04.240+1000 I NETWORK  [thread1] connection accepted from 127.0.0.1:57134 #1 (1 connection now open)
-2017-09-04T16:12:04.248+1000 I -        [conn4] end connection 192.168.179.118:57137 (2 connections now open)
-2017-09-04T16:12:04.248+1000 I -        [conn3] end connection 192.168.179.118:57136 (2 connections now open)
-2017-09-04T16:12:07.365+1000 I NETWORK  [thread1] connection accepted from 192.168.179.118:57138 #5 (1 connection now open)
-2017-09-04T16:12:07.365+1000 I NETWORK  [conn5] received client metadata from 192.168.179.118:57138 conn5: { application: { name: "94a622f1747659c540bfa9f105de145f" }, driver: { name: "83c67e6f57c4fa51f4ac1565e74456b9", version: "a28f9918e19547698799858a6d65f46a" }, os: { type: "0ebb1448f597a99a0f73e9da2c2644be", name: "47b6216057388787126f850c1860ea8d", architecture: "270ae8f00c4f8a33677ce5f47a000a44", version: "264d624a1eed6d7aea5472819ab56933" } }
-2017-09-04T16:12:13.917+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:12:13.917+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
-2017-09-04T16:12:19.922+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true }
+2017-09-04T16:12:04.248+1000 I -        [conn4] end connection 192.168.107.66:57137 (2 connections now open)
+2017-09-04T16:12:04.248+1000 I -        [conn3] end connection 192.168.107.66:57136 (2 connections now open)
+2017-09-04T16:12:07.365+1000 I NETWORK  [thread1] connection accepted from 192.168.107.66:57138 #5 (1 connection now open)
+2017-09-04T16:12:07.365+1000 I NETWORK  [conn5] received client metadata from 192.168.107.66:57138 conn5: { application: { name: "94a622f1747659c540bfa9f105de145f" }, driver: { name: "83c67e6f57c4fa51f4ac1565e74456b9", version: "a28f9918e19547698799858a6d65f46a" }, os: { type: "0ebb1448f597a99a0f73e9da2c2644be", name: "47b6216057388787126f850c1860ea8d", architecture: "270ae8f00c4f8a33677ce5f47a000a44", version: "264d624a1eed6d7aea5472819ab56933" } }
+2017-09-04T16:12:13.917+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:13.917+1000 I COMMAND  [conn5] command lightseagreen.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:19.922+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true }
 2017-09-04T16:12:19.922+1000 D -        [conn5] reloading view catalog for database test
-2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] create collection darkturquoise.darkturquoise {}
-2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] stored meta data for darkturquoise.darkturquoise @ RecordId(4)
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] create collection lightseagreen.lightseagreen {}
+2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] stored meta data for lightseagreen.lightseagreen @ RecordId(4)
 2017-09-04T16:12:19.922+1000 D STORAGE  [conn5] WiredTigerKVEngine::createRecordStore uri: table:collection-5--873095094229448774 config: type=file,memory_page_max=10m,split_pct=90,leaf_value_max=64MB,checksum=on,block_compressor=snappy,,key_format=q,value_format=u,app_metadata=(formatVersion=1)
 2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] WiredTigerUtil::checkApplicationMetadataFormatVersion  uri: table:collection-5--873095094229448774 ok range 1 -> 1 current: 1
-2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] darkturquoise.darkturquoise: clearing plan cache - collection info cache reset
+2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] lightseagreen.lightseagreen: clearing plan cache - collection info cache reset
 2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] WiredTigerKVEngine::createSortedDataInterface ident: index-6--873095094229448774 config: type=file,internal_page_max=16k,leaf_page_max=16k,checksum=on,prefix_compression=true,block_compressor=,,,,key_format=u,value_format=u,app_metadata=(formatVersion=8,infoObj={ "59b943d2fe6aede1820f470ac1e94e1a" : 2, "02ba83662661dcf7d3d3582a9f3e64f0" : { "ba446a583e8ec693391bce36164d9dc7" : 1 }, "984fecde60a13b93d99af5d40c85f9ee" : "ecd619ef9879c9ed846ac73b2aa533c7", "fd3dd255c469e25ec997b6577eb217ec" : "dbb3565f7116ced1ad598bb12d6cd05e" }),
 2017-09-04T16:12:19.948+1000 D STORAGE  [conn5] create uri: table:index-6--873095094229448774 config: type=file,internal_page_max=16k,leaf_page_max=16k,checksum=on,prefix_compression=true,block_compressor=,,,,key_format=u,value_format=u,app_metadata=(formatVersion=8,infoObj={ "59b943d2fe6aede1820f470ac1e94e1a" : 2, "02ba83662661dcf7d3d3582a9f3e64f0" : { "ba446a583e8ec693391bce36164d9dc7" : 1 }, "984fecde60a13b93d99af5d40c85f9ee" : "ecd619ef9879c9ed846ac73b2aa533c7", "fd3dd255c469e25ec997b6577eb217ec" : "dbb3565f7116ced1ad598bb12d6cd05e" }),
 2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] WiredTigerUtil::checkApplicationMetadataFormatVersion  uri: table:index-6--873095094229448774 ok range 6 -> 8 current: 8
-2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] darkturquoise.darkturquoise: clearing plan cache - collection info cache reset
+2017-09-04T16:12:19.976+1000 D STORAGE  [conn5] lightseagreen.lightseagreen: clearing plan cache - collection info cache reset
 2017-09-04T16:12:19.977+1000 D INDEX    [conn5] marking index _id_ as ready in snapshot id 50
 2017-09-04T16:12:19.977+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
-2017-09-04T16:12:19.977+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 3, w: 3 } }, Database: { acquireCount: { w: 2, W: 1 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_command 55ms
-2017-09-04T16:12:19.979+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:12:19.980+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
-2017-09-04T16:12:22.712+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true }
+2017-09-04T16:12:19.977+1000 I COMMAND  [conn5] command lightseagreen.lightseagreen appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec3c250e507159808f0'), key: 1.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 3, w: 3 } }, Database: { acquireCount: { w: 2, W: 1 } }, Collection: { acquireCount: { w: 2 } } } protocol:op_command 55ms
+2017-09-04T16:12:19.979+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:19.980+1000 I COMMAND  [conn5] command lightseagreen.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:22.712+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true }
 2017-09-04T16:12:22.712+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
-2017-09-04T16:12:22.712+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
-2017-09-04T16:12:22.715+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:12:22.715+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
-2017-09-04T16:12:24.707+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true }
+2017-09-04T16:12:22.712+1000 I COMMAND  [conn5] command lightseagreen.lightseagreen appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec6c250e507159808f1'), key: 2.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:22.715+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:22.715+1000 I COMMAND  [conn5] command lightseagreen.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:24.707+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true }
 2017-09-04T16:12:24.707+1000 D REPL     [conn5] Waiting for write concern. OpTime: { ts: Timestamp 0|0, t: -1 }, write concern: { w: 1, wtimeout: 0 }
-2017-09-04T16:12:24.707+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
-2017-09-04T16:12:24.708+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:12:24.708+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
-2017-09-04T16:12:40.866+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { find: "303b5c8988601647873b4ffd247d83cb", filter: { darkcyan.cloudberry: 1.0 } }
-2017-09-04T16:12:40.866+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { darkcyan.cloudberry: 1.0 } sort: {} projection: {}, planSummary: COLLSCAN
-2017-09-04T16:12:40.866+1000 I COMMAND  [conn5] command darkturquoise.darkturquoise appName: "94a622f1747659c540bfa9f105de145f" command: find { find: "303b5c8988601647873b4ffd247d83cb", filter: { darkcyan.cloudberry: 1.0 } } planSummary: COLLSCAN keysExamined:0 docsExamined:3 cursorExhausted:1 numYields:0 nreturned:0 reslen:82 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_command 0ms
-2017-09-04T16:12:40.867+1000 D COMMAND  [conn5] run command darkturquoise.$cmd { isMaster: 1.0, forShell: 1.0 }
-2017-09-04T16:12:40.867+1000 I COMMAND  [conn5] command darkturquoise.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
-2017-09-04T16:12:42.631+1000 D NETWORK  [conn5] SocketException: remote: 192.168.179.118:57138 error: 9001 socket exception [CLOSED] server [192.168.179.118:57138]
-2017-09-04T16:12:42.631+1000 I -        [conn5] end connection 192.168.179.118:57138 (1 connection now open)
-2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 192.168.179.118:57139 #6 (1 connection now open)
+2017-09-04T16:12:24.707+1000 I COMMAND  [conn5] command lightseagreen.lightseagreen appName: "94a622f1747659c540bfa9f105de145f" command: insert { insert: "303b5c8988601647873b4ffd247d83cb", documents: [ { _id: ObjectId('59aceec8c250e507159808f2'), key: 3.0 } ], ordered: true } ninserted:1 keysInserted:1 numYields:0 reslen:29 locks:{ Global: { acquireCount: { r: 1, w: 1 } }, Database: { acquireCount: { w: 1 } }, Collection: { acquireCount: { w: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:24.708+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:24.708+1000 I COMMAND  [conn5] command lightseagreen.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:40.866+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { find: "303b5c8988601647873b4ffd247d83cb", filter: { lightgoldenrodyellow.western.raspberry: 1.0 } }
+2017-09-04T16:12:40.866+1000 D QUERY    [conn5] Only one plan is available; it will be run but will not be cached. query: { lightgoldenrodyellow.western.raspberry: 1.0 } sort: {} projection: {}, planSummary: COLLSCAN
+2017-09-04T16:12:40.866+1000 I COMMAND  [conn5] command lightseagreen.lightseagreen appName: "94a622f1747659c540bfa9f105de145f" command: find { find: "303b5c8988601647873b4ffd247d83cb", filter: { lightgoldenrodyellow.western.raspberry: 1.0 } } planSummary: COLLSCAN keysExamined:0 docsExamined:3 cursorExhausted:1 numYields:0 nreturned:0 reslen:82 locks:{ Global: { acquireCount: { r: 2 } }, Database: { acquireCount: { r: 1 } }, Collection: { acquireCount: { r: 1 } } } protocol:op_command 0ms
+2017-09-04T16:12:40.867+1000 D COMMAND  [conn5] run command lightseagreen.$cmd { isMaster: 1.0, forShell: 1.0 }
+2017-09-04T16:12:40.867+1000 I COMMAND  [conn5] command lightseagreen.$cmd appName: "94a622f1747659c540bfa9f105de145f" command: isMaster { isMaster: 1.0, forShell: 1.0 } numYields:0 reslen:174 locks:{} protocol:op_command 0ms
+2017-09-04T16:12:42.631+1000 D NETWORK  [conn5] SocketException: remote: 192.168.107.66:57138 error: 9001 socket exception [CLOSED] server [192.168.107.66:57138]
+2017-09-04T16:12:42.631+1000 I -        [conn5] end connection 192.168.107.66:57138 (1 connection now open)
+2017-09-04T16:12:47.997+1000 I NETWORK  [thread1] connection accepted from 192.168.107.66:57139 #6 (1 connection now open)
 2017-09-04T16:12:48.001+1000 D COMMAND  [conn7] run command admin.$cmd { ping: 1 }
 2017-09-04T16:12:48.001+1000 I COMMAND  [conn7] command admin.$cmd command: ping { ping: 1 } numYields:0 reslen:37 locks:{} protocol:op_query 0ms
-2017-09-04T16:12:48.001+1000 D NETWORK  [conn6] SocketException: remote: 192.168.179.118:57139 error: 9001 socket exception [CLOSED] server [192.168.179.118:57139]
-2017-09-04T16:12:48.001+1000 D NETWORK  [conn7] SocketException: remote: 192.168.179.118:57140 error: 9001 socket exception [CLOSED] server [192.168.179.118:57140]
-2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 192.168.179.118:57139 (2 connections now open)
-2017-09-04T16:12:48.001+1000 I -        [conn7] end connection 192.168.179.118:57140 (2 connections now open)
+2017-09-04T16:12:48.001+1000 D NETWORK  [conn6] SocketException: remote: 192.168.107.66:57139 error: 9001 socket exception [CLOSED] server [192.168.107.66:57139]
+2017-09-04T16:12:48.001+1000 D NETWORK  [conn7] SocketException: remote: 192.168.107.66:57140 error: 9001 socket exception [CLOSED] server [192.168.107.66:57140]
+2017-09-04T16:12:48.001+1000 I -        [conn6] end connection 192.168.107.66:57139 (2 connections now open)
+2017-09-04T16:12:48.001+1000 I -        [conn7] end connection 192.168.107.66:57140 (2 connections now open)
 2017-09-04T16:12:48.020+1000 I CONTROL  [signalProcessingThread] got signal 15 (Terminated: 15), will terminate after current cmd ends
 2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] shutdown: going to close listening sockets...
 2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] closing listening socket: 8
 2017-09-04T16:12:48.020+1000 I NETWORK  [signalProcessingThread] closing listening socket: 9
-2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] removing socket file: /khaki.tomato
+2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] removing socket file: /aliceblue.mango
 2017-09-04T16:12:48.021+1000 I NETWORK  [signalProcessingThread] shutdown: going to flush diaglog...
 2017-09-04T16:12:48.021+1000 D QUERY    [signalProcessingThread] received interrupt request for unknown op: 87  known ops:
 2017-09-04T16:12:48.021+1000 I FTDC     [signalProcessingThread] Shutting down full-time diagnostic data capture
 2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: admin.system.version
 2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: local.startup_log
-2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: darkturquoise.darkturquoise
+2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: lightseagreen.lightseagreen
 2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] ~WiredTigerRecordStore for: _mdb_catalog
 2017-09-04T16:12:48.022+1000 I STORAGE  [signalProcessingThread] WiredTigerKVEngine shutting down
 2017-09-04T16:12:48.022+1000 D STORAGE  [signalProcessingThread] WiredTigerSizeStorer::storeInto table:_mdb_catalog -> { numRecords: 4, dataSize: 1341 }


### PR DESCRIPTION
mtools dependency created some issue with timestamp rendering in fruitsalad. For example, the log line:

```
2017-08-25T22:23:49.097+0000 I COMMAND [conn0]
```

was rendered as:

```
2017-08-25T22:23:49.970+0000 I COMMAND [conn0]
```

This created an impression that the server time is moving forward/backward after the log files are processed with fruitsalad.

Removing the mtools dependency seems to fix this issue.

I have also added some basic tests to fruitsalad.