### PR TITLE
fix:  resolve issue with AttributeError: 'int' 

### DIFF
--- a/fruitsalad.py
+++ b/fruitsalad.py
@@ -113,7 +113,7 @@ class FruitSaladTool():
         # Dont obfuscate well known system namespaces
         if ns in ['local.oplog.rs', 'oplog.rs']:
             return ns
-        parts = ns.split('.')
+        parts = str(ns).split('.')
         replaced = []
         for i, part in enumerate(parts):
             if i == 0 and part in ['system', 'local', 'admin', 'config'] or part in ['$cmd']:


### PR DESCRIPTION
fix:  resolve issue with AttributeError: 'int'  object has no attribute 'split' when ns is an int

e.g.

```
"ns":"admin.aggregate","collectionType":"admin","appName":"MongoDB Automation Agent v13.31.2.9389 (git: e96607b24b994e597e767d5466f0867f47e0ac06)","command":{"aggregate":1,"pipeline":
```